### PR TITLE
Apply PR #9 review suggestions

### DIFF
--- a/.github/workflows/publish-contract-model.yml
+++ b/.github/workflows/publish-contract-model.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv .venv --python "${PYTHON_VERSION}"
-          uv sync --frozen --python .venv/bin/python
+          uv sync --frozen --python .venv/bin/python --extra dev --extra test
 
       - name: Re-export contract model
         env:

--- a/.github/workflows/publish-contract-type-runtime-model.yml
+++ b/.github/workflows/publish-contract-type-runtime-model.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv .venv --python "${PYTHON_VERSION}"
-          uv sync --frozen --python .venv/bin/python
+          uv sync --frozen --python .venv/bin/python --extra dev --extra test
 
       - name: Train runtime contract-type model
         env:
@@ -76,7 +76,7 @@ jobs:
           from lexnlp.ml.catalog import CATALOG
           import os
 
-          tag = (os.getenv("MODEL_TAG") or "").strip() or "pipeline/contract-type/0.2-runtime"
+          tag = os.environ["MODEL_TAG"]
           path = CATALOG / tag / CONTRACT_TYPE_MODEL_FILENAME
           print(path)
           PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ This document is a quick-start guide for coding agents working in this repositor
 Use Python 3.11 in a local `.venv`.
 
 ```bash
-cd /Users/jackeames/Downloads/LexNLP
+cd /path/to/LexNLP
 uv python install 3.11
 uv venv --python 3.11 .venv
 uv sync --frozen --python .venv/bin/python --extra dev --extra test

--- a/MIGRATION_RUNBOOK.md
+++ b/MIGRATION_RUNBOOK.md
@@ -17,7 +17,7 @@ Legacy files are retained for historical reproduction only:
 ## 2) Fresh Setup
 
 ```bash
-cd /Users/jackeames/Downloads/LexNLP
+cd /path/to/LexNLP
 uv python install 3.11
 uv venv --python 3.11 .venv
 uv sync --frozen --python .venv/bin/python --extra dev --extra test

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ by contacting ContraxSuite Licensing at <<license@contraxsuite.com>>.
 
 ## Quick Setup (uv + pyproject)
 ```bash
-cd /Users/jackeames/Downloads/LexNLP
+cd /path/to/LexNLP
 uv python install 3.11
 uv venv --python 3.11 .venv
 uv pip install --python .venv/bin/python -e ".[dev,test]"

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Quick Setup (uv + pyproject)
 
 .. code:: bash
 
-   cd /Users/jackeames/Downloads/LexNLP
+   cd /path/to/LexNLP
    uv python install 3.11
    uv venv --python 3.11 .venv
    uv pip install --python .venv/bin/python -e ".[dev,test]"

--- a/lexnlp/extract/en/contracts/runtime_model.py
+++ b/lexnlp/extract/en/contracts/runtime_model.py
@@ -154,7 +154,13 @@ def write_pipeline_to_catalog(
     pipeline: Pipeline,
     target_tag: str,
     force: bool,
-) -> Path:
+) -> Tuple[Path, bool]:
+    """
+    Returns:
+        A ``(destination_path, wrote)`` tuple where ``wrote`` is ``True`` when
+        the pipeline was serialized to disk (i.e., either ``force`` was set or
+        the destination did not already exist).
+    """
     from lexnlp.ml.catalog import CATALOG
 
     destination_dir = CATALOG / target_tag
@@ -162,11 +168,15 @@ def write_pipeline_to_catalog(
     destination_path = destination_dir / CONTRACT_TYPE_MODEL_FILENAME
 
     if destination_path.exists() and not force:
-        return destination_path
+        LOGGER.debug(
+            "Artifact already exists, skipping write (force=False): %s",
+            destination_path,
+        )
+        return destination_path, False
 
     with destination_path.open("wb") as model_file:
         pickle.dump(pipeline, model_file)
-    return destination_path
+    return destination_path, True
 
 
 def ensure_runtime_contract_type_model(
@@ -196,7 +206,6 @@ def ensure_runtime_contract_type_model(
                 exc,
                 exc_info=True,
             )
-            pass
 
     corpus_archive = ensure_tag_downloaded(CONTRACT_TYPE_CORPUS_TAG)
     texts, labels, _counts = collect_contract_type_samples(
@@ -205,7 +214,7 @@ def ensure_runtime_contract_type_model(
         head_character_n=head_character_n,
     )
     pipeline = train_contract_type_pipeline(texts, labels, random_state=random_state)
-    destination_path = write_pipeline_to_catalog(
+    destination_path, _wrote = write_pipeline_to_catalog(
         pipeline=pipeline,
         target_tag=target_tag,
         force=True,

--- a/lexnlp/extract/en/contracts/tests/test_runtime_model.py
+++ b/lexnlp/extract/en/contracts/tests/test_runtime_model.py
@@ -33,7 +33,7 @@ def test_ensure_runtime_contract_type_model_force_trains(monkeypatch, tmp_path):
         calls.append(("write_pipeline_to_catalog", target_tag, force))
         destination = tmp_path / "pipeline_contract_type_classifier.cloudpickle"
         destination.write_bytes(b"dummy")
-        return destination
+        return destination, True
 
     monkeypatch.setattr(runtime_model, "ensure_tag_downloaded", ensure_tag_downloaded)
     monkeypatch.setattr(runtime_model, "collect_contract_type_samples", collect_samples)

--- a/lexnlp/extract/en/contracts/tests/test_runtime_model.py
+++ b/lexnlp/extract/en/contracts/tests/test_runtime_model.py
@@ -55,3 +55,148 @@ def test_ensure_runtime_contract_type_model_force_trains(monkeypatch, tmp_path):
     assert result == tmp_path / "pipeline_contract_type_classifier.cloudpickle"
     assert ("write_pipeline_to_catalog", runtime_model.RUNTIME_CONTRACT_TYPE_TAG, True) in calls
 
+
+# ---------------------------------------------------------------------------
+# write_pipeline_to_catalog – returns Tuple[Path, bool]
+# ---------------------------------------------------------------------------
+
+
+def test_write_pipeline_to_catalog_returns_path_and_true_when_new(monkeypatch, tmp_path):
+    """
+    When the destination does not yet exist, write_pipeline_to_catalog must
+    serialize the pipeline and return (path, True).
+    """
+    import pickle
+    from lexnlp.extract.en.contracts import runtime_model
+
+    monkeypatch.setattr(runtime_model, "CATALOG", tmp_path, raising=False)
+
+    # Patch the CATALOG import inside write_pipeline_to_catalog
+    import lexnlp.ml.catalog as catalog_mod
+    monkeypatch.setattr(catalog_mod, "CATALOG", tmp_path)
+
+    # Use a simple picklable object as the "pipeline".
+    dummy_pipeline = {"weights": [1, 2, 3]}
+
+    destination, wrote = runtime_model.write_pipeline_to_catalog(
+        pipeline=dummy_pipeline,
+        target_tag="pipeline/test/0.1",
+        force=False,
+    )
+
+    assert wrote is True
+    assert destination.exists()
+    assert destination.name == runtime_model.CONTRACT_TYPE_MODEL_FILENAME
+    # Verify the content is the serialized pipeline.
+    with destination.open("rb") as f:
+        loaded = pickle.load(f)
+    assert loaded == dummy_pipeline
+
+
+def test_write_pipeline_to_catalog_returns_false_when_artifact_exists(monkeypatch, tmp_path):
+    """
+    When the destination already exists and force=False, the function must
+    NOT overwrite it and must return (path, False).
+    """
+    from lexnlp.extract.en.contracts import runtime_model
+
+    import lexnlp.ml.catalog as catalog_mod
+    monkeypatch.setattr(catalog_mod, "CATALOG", tmp_path)
+
+    # Pre-create the destination file.
+    target_dir = tmp_path / "pipeline" / "test" / "0.1"
+    target_dir.mkdir(parents=True)
+    existing_file = target_dir / runtime_model.CONTRACT_TYPE_MODEL_FILENAME
+    existing_file.write_bytes(b"original content")
+
+    dummy_pipeline = {"weights": [9, 9, 9]}
+
+    destination, wrote = runtime_model.write_pipeline_to_catalog(
+        pipeline=dummy_pipeline,
+        target_tag="pipeline/test/0.1",
+        force=False,
+    )
+
+    assert wrote is False
+    assert destination == existing_file
+    # Content must be unchanged.
+    assert destination.read_bytes() == b"original content"
+
+
+def test_write_pipeline_to_catalog_force_overwrites_existing(monkeypatch, tmp_path):
+    """
+    When force=True, an existing artifact must be overwritten and (path, True)
+    must be returned.
+    """
+    import pickle
+    from lexnlp.extract.en.contracts import runtime_model
+
+    import lexnlp.ml.catalog as catalog_mod
+    monkeypatch.setattr(catalog_mod, "CATALOG", tmp_path)
+
+    target_dir = tmp_path / "pipeline" / "test" / "0.2"
+    target_dir.mkdir(parents=True)
+    existing_file = target_dir / runtime_model.CONTRACT_TYPE_MODEL_FILENAME
+    existing_file.write_bytes(b"old content")
+
+    new_pipeline = {"version": 2}
+
+    destination, wrote = runtime_model.write_pipeline_to_catalog(
+        pipeline=new_pipeline,
+        target_tag="pipeline/test/0.2",
+        force=True,
+    )
+
+    assert wrote is True
+    assert destination == existing_file
+    with destination.open("rb") as f:
+        loaded = pickle.load(f)
+    assert loaded == new_pipeline
+
+
+def test_write_pipeline_to_catalog_creates_parent_directories(monkeypatch, tmp_path):
+    """
+    The function must create any missing parent directories for the destination.
+    """
+    from lexnlp.extract.en.contracts import runtime_model
+
+    import lexnlp.ml.catalog as catalog_mod
+    monkeypatch.setattr(catalog_mod, "CATALOG", tmp_path)
+
+    # Ensure the nested tag directories do not exist yet.
+    deep_tag = "pipeline/deep/nested/tag/0.1"
+    destination, wrote = runtime_model.write_pipeline_to_catalog(
+        pipeline={"x": 1},
+        target_tag=deep_tag,
+        force=False,
+    )
+
+    assert wrote is True
+    assert destination.parent.is_dir()
+
+
+def test_ensure_runtime_contract_type_model_no_force_returns_cached(monkeypatch, tmp_path):
+    """
+    When force=False and the catalog already has the target tag, the existing
+    path is returned immediately without retraining.
+    """
+    from lexnlp.extract.en.contracts import runtime_model
+
+    existing_path = tmp_path / "model.cloudpickle"
+    existing_path.write_bytes(b"cached")
+
+    import lexnlp.ml.catalog as catalog_mod
+
+    def fake_get_path(tag: str) -> object:
+        if tag == runtime_model.RUNTIME_CONTRACT_TYPE_TAG:
+            return existing_path
+        raise FileNotFoundError(tag)
+
+    monkeypatch.setattr(catalog_mod, "get_path_from_catalog", fake_get_path)
+
+    result = runtime_model.ensure_runtime_contract_type_model(
+        target_tag=runtime_model.RUNTIME_CONTRACT_TYPE_TAG,
+        force=False,
+    )
+
+    assert result == existing_path

--- a/lexnlp/extract/es/regulations.py
+++ b/lexnlp/extract/es/regulations.py
@@ -52,20 +52,11 @@ class RegulationsParser:
         dtypes = {'trigger': str, 'position': str}
         if not self.regulations_dataframe:
             path = os.path.join(lexnlp_base_path, 'lexnlp/config/es/es_regulations.csv')
-            try:
-                # pandas >= 1.3
-                self.regulations_dataframe = read_csv(
-                    path,
-                    encoding='utf-8',
-                    on_bad_lines='skip',
-                    converters=dtypes)
-            except TypeError:
-                # pandas < 1.3
-                self.regulations_dataframe = read_csv(
-                    path,
-                    encoding='utf-8',
-                    error_bad_lines=False,
-                    converters=dtypes)
+            self.regulations_dataframe = read_csv(
+                path,
+                encoding='utf-8',
+                on_bad_lines='skip',
+                converters=dtypes)
         subset = self.regulations_dataframe[['trigger', 'position']]
         tuples = [tuple(x) for x in subset.values]
         self.start_triggers = [t[0] for t in tuples if t[1] == 'start']

--- a/lexnlp/ml/catalog/__init__.py
+++ b/lexnlp/ml/catalog/__init__.py
@@ -11,6 +11,7 @@ __email__ = "support@contraxsuite.com"
 
 # standard library
 import os
+import threading
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -64,6 +65,7 @@ def _resolve_catalog_dir() -> Path:
 CATALOG: Path = _resolve_catalog_dir()
 
 _TAG_DICT_CACHE: Optional[Dict[str, Path]] = None
+_TAG_DICT_LOCK = threading.Lock()
 
 
 def _build_tag_dict() -> Dict[str, Path]:
@@ -98,7 +100,9 @@ def invalidate_catalog_cache() -> None:
 def _get_tag_dict_cached() -> Dict[str, Path]:
     global _TAG_DICT_CACHE
     if _TAG_DICT_CACHE is None:
-        _TAG_DICT_CACHE = _build_tag_dict()
+        with _TAG_DICT_LOCK:
+            if _TAG_DICT_CACHE is None:
+                _TAG_DICT_CACHE = _build_tag_dict()
     return _TAG_DICT_CACHE
 
 

--- a/lexnlp/ml/catalog/download.py
+++ b/lexnlp/ml/catalog/download.py
@@ -234,7 +234,6 @@ def download_github_release(tag: str, prompt_user: bool = True) -> None:
 
     def _get_asset() -> Dict[str, Any]:
         response: Response = GitHubReleaseDownloader.get_tag(tag)
-        response.raise_for_status()
         return GitHubReleaseDownloader.get_asset(response)
 
     def _download_asset() -> None:

--- a/lexnlp/ml/catalog/tests/test_catalog_path.py
+++ b/lexnlp/ml/catalog/tests/test_catalog_path.py
@@ -1,5 +1,4 @@
 import importlib
-from pathlib import Path
 
 
 def test_catalog_path_resolves_on_fresh_environment(tmp_path):
@@ -24,7 +23,6 @@ def test_catalog_path_falls_back_to_home_when_nltk_path_empty(tmp_path, monkeypa
     import lexnlp.ml.catalog as catalog
 
     original_paths = list(nltk.data.path)
-    original_home = Path.home()
     try:
         fake_home = tmp_path / "home"
         monkeypatch.setenv("HOME", str(fake_home))
@@ -36,5 +34,4 @@ def test_catalog_path_falls_back_to_home_when_nltk_path_empty(tmp_path, monkeypa
         assert not catalog.CATALOG.exists()
     finally:
         nltk.data.path = original_paths
-        monkeypatch.setenv("HOME", str(original_home))
         importlib.reload(catalog)

--- a/lexnlp/ml/catalog/tests/test_catalog_path.py
+++ b/lexnlp/ml/catalog/tests/test_catalog_path.py
@@ -1,4 +1,5 @@
 import importlib
+import threading
 
 
 def test_catalog_path_resolves_on_fresh_environment(tmp_path):
@@ -35,3 +36,107 @@ def test_catalog_path_falls_back_to_home_when_nltk_path_empty(tmp_path, monkeypa
     finally:
         nltk.data.path = original_paths
         importlib.reload(catalog)
+
+
+# ---------------------------------------------------------------------------
+# Thread-safe double-checked locking for _get_tag_dict_cached
+# ---------------------------------------------------------------------------
+
+
+def test_get_tag_dict_cached_builds_cache_once(tmp_path):
+    """
+    _get_tag_dict_cached must populate _TAG_DICT_CACHE exactly once, even when
+    called multiple times sequentially.
+    """
+    import lexnlp.ml.catalog as catalog
+
+    catalog.invalidate_catalog_cache()
+
+    # Create a single file under CATALOG so _build_tag_dict returns something.
+    fake_tag_dir = tmp_path / "pipeline" / "test" / "0.1"
+    fake_tag_dir.mkdir(parents=True)
+    fake_file = fake_tag_dir / "model.pkl"
+    fake_file.write_bytes(b"model")
+
+    original_catalog = catalog.CATALOG
+    catalog.CATALOG = tmp_path
+    try:
+        result1 = catalog._get_tag_dict_cached()
+        result2 = catalog._get_tag_dict_cached()
+        assert result1 is result2  # Same dict object – no rebuild.
+    finally:
+        catalog.CATALOG = original_catalog
+        catalog.invalidate_catalog_cache()
+
+
+def test_get_tag_dict_cached_thread_safety(tmp_path):
+    """
+    Concurrent calls to _get_tag_dict_cached must not build the cache more
+    than once (double-checked locking correctness).
+    """
+    import lexnlp.ml.catalog as catalog
+
+    build_count = []
+    original_build = catalog._build_tag_dict
+
+    def counting_build():
+        build_count.append(1)
+        return original_build()
+
+    catalog.invalidate_catalog_cache()
+    catalog._build_tag_dict = counting_build  # type: ignore[assignment]
+
+    original_catalog = catalog.CATALOG
+    catalog.CATALOG = tmp_path
+
+    errors: list[Exception] = []
+    results: list[object] = []
+
+    def call_cached():
+        try:
+            results.append(catalog._get_tag_dict_cached())
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=call_cached) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    catalog._build_tag_dict = original_build  # type: ignore[assignment]
+    catalog.CATALOG = original_catalog
+    catalog.invalidate_catalog_cache()
+
+    assert not errors, f"Thread errors: {errors}"
+    assert len(results) == 10
+    # All threads must receive the same dict object.
+    first = results[0]
+    assert all(r is first for r in results)
+    # _build_tag_dict must have been called at most once.
+    assert len(build_count) <= 1
+
+
+def test_invalidate_catalog_cache_clears_cache(tmp_path):
+    """
+    invalidate_catalog_cache must reset _TAG_DICT_CACHE so the next call to
+    _get_tag_dict_cached rebuilds it.
+    """
+    import lexnlp.ml.catalog as catalog
+
+    original_catalog = catalog.CATALOG
+    catalog.CATALOG = tmp_path
+    try:
+        # Warm up the cache.
+        first = catalog._get_tag_dict_cached()
+        assert catalog._TAG_DICT_CACHE is not None
+
+        catalog.invalidate_catalog_cache()
+        assert catalog._TAG_DICT_CACHE is None
+
+        # Rebuilding after invalidation yields a fresh dict.
+        second = catalog._get_tag_dict_cached()
+        assert second is not first
+    finally:
+        catalog.CATALOG = original_catalog
+        catalog.invalidate_catalog_cache()

--- a/lexnlp/ml/predictor.py
+++ b/lexnlp/ml/predictor.py
@@ -89,7 +89,7 @@ class ProbabilityPredictor(ABC):
         self._patch_legacy_estimator_attributes()
 
         # Fix AttributeError: 'MinMaxScaler' object has no attribute 'clip'
-        for _, name, transform in self.pipeline._iter(with_final=False):
+        for _, _name, transform in self.pipeline._iter(with_final=False):
             transform.clip = hasattr(transform, 'clip') and transform.clip
 
         self._sanity_check()

--- a/lexnlp/nlp/en/segments/titles.py
+++ b/lexnlp/nlp/en/segments/titles.py
@@ -230,7 +230,7 @@ def get_titles(text, window_pre=3, window_post=3, score_threshold=0.5) -> Genera
 
     # Predict title lines
     # Avoid pandas dtype deprecation noise in sklearn validation by passing a numpy array.
-    predicted_lines = SECTION_SEGMENTER_MODEL.predict_proba(feature_data.to_numpy())
+    predicted_lines = SECTION_SEGMENTER_MODEL.predict_proba(feature_data.to_numpy(dtype=float))
     predicted_df = pandas.DataFrame(predicted_lines, columns=["prob_false", "prob_true"])
     title_lines = predicted_df.loc[predicted_df["prob_true"] >= score_threshold, :].index.tolist()
 

--- a/lexnlp/utils/amount_delimiting.py
+++ b/lexnlp/utils/amount_delimiting.py
@@ -176,7 +176,11 @@ def infer_delimiters(
     # whenever locale resolution does not match those conventions.
     if (
         _locale.lower().startswith('de_de')
-        and (decimal_delimiter != ',' or group_delimiter != '.')
+        and (
+            decimal_delimiter != ','
+            or group_delimiter != '.'
+            or grouping != [3, 3, 0]
+        )
     ):
         decimal_delimiter = ','
         group_delimiter = '.'

--- a/lexnlp/utils/tests/test_amount_delimiting.py
+++ b/lexnlp/utils/tests/test_amount_delimiting.py
@@ -1,0 +1,227 @@
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+"""Tests for lexnlp/utils/amount_delimiting.py.
+
+Covers changes introduced in the PR:
+  - infer_delimiters: de_DE locale fix is now also triggered when the
+    grouping list does not match [3, 3, 0], even if the delimiter characters
+    happen to be correct.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from lexnlp.utils.amount_delimiting import infer_delimiters
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_de_de_conventions(
+    decimal_delimiter: str = ",",
+    group_delimiter: str = ".",
+    grouping: list | None = None,
+):
+    """
+    Return a context-manager that patches LocaleContextManager so locale.localeconv()
+    returns the requested values for any de_DE call.
+    """
+    if grouping is None:
+        grouping = [3, 3, 0]
+
+    # locale.localeconv() is called inside the LocaleContextManager context.
+    import locale
+
+    fake_conventions = {
+        "decimal_point": decimal_delimiter,
+        "thousands_sep": group_delimiter,
+        "grouping": grouping,
+    }
+
+    class FakeLocaleContextManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    return (
+        patch(
+            "lexnlp.utils.amount_delimiting.LocaleContextManager",
+            FakeLocaleContextManager,
+        ),
+        patch("lexnlp.utils.amount_delimiting.locale.localeconv", return_value=fake_conventions),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core tests for the new grouping-check condition
+# ---------------------------------------------------------------------------
+
+
+class TestDeDEGroupingFix:
+    """
+    The PR added ``or grouping != [3, 3, 0]`` to the de_DE correction
+    condition.  Previously, if the locale correctly returned ',' and '.' but
+    with an unexpected grouping list (e.g., [3, 0] or []), the override was
+    skipped and wrong inference could follow.  Now the fix is applied whenever
+    any of the three values differ from the canonical de_DE conventions.
+    """
+
+    def test_correct_de_de_conventions_are_not_overridden(self):
+        """
+        When locale already returns the canonical de_DE values, the fix is a
+        no-op — infer_delimiters should still work correctly.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=",",
+            group_delimiter=".",
+            grouping=[3, 3, 0],
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("10.800", "de_DE")
+        # "10.800" in German: '.' is a thousands separator, no decimal part.
+        assert result is not None
+        assert result["group_delimiter"] == "."
+
+    def test_wrong_grouping_triggers_de_de_fix(self):
+        """
+        When locale returns correct delimiters but wrong grouping, the fix must
+        still be applied.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=",",
+            group_delimiter=".",
+            grouping=[3, 0],  # non-canonical grouping
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("10.800", "de_DE")
+        # After the fix the canonical grouping [3,3,0] is enforced.
+        assert result is not None
+        assert result["group_delimiter"] == "."
+
+    def test_wrong_decimal_delimiter_triggers_fix(self):
+        """
+        When locale falls back to en_US conventions (decimal='.', group=','),
+        the fix must correct to de_DE canonical values.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=".",
+            group_delimiter=",",
+            grouping=[3, 3, 0],
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("10.800", "de_DE")
+        assert result is not None
+        # After fix: group_delimiter must be '.' (German convention).
+        assert result["group_delimiter"] == "."
+
+    def test_wrong_group_delimiter_triggers_fix(self):
+        """
+        When locale returns correct decimal delimiter but wrong group delimiter,
+        the fix is triggered.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=",",
+            group_delimiter=" ",  # space instead of period
+            grouping=[3, 3, 0],
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("10.800", "de_DE")
+        assert result is not None
+        assert result["group_delimiter"] == "."
+
+    def test_all_wrong_triggers_fix(self):
+        """
+        When locale returns completely wrong values, the fix corrects all three.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=".",
+            group_delimiter=",",
+            grouping=[3, 0],
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("1.000,50", "de_DE")
+        # "1.000,50" in German is 1000.50; '.' = group, ',' = decimal.
+        assert result is not None
+        assert result["decimal_delimiter"] == ","
+        assert result["group_delimiter"] == "."
+
+    def test_de_de_prefix_case_insensitive(self):
+        """
+        The fix condition uses _locale.lower().startswith('de_de') so mixed-case
+        locale strings should also trigger the fix.
+        """
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=".",
+            group_delimiter=",",
+            grouping=[3, 3, 0],
+        )
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("10.800", "DE_DE")
+        assert result is not None
+        # The fix must have been applied.
+        assert result["group_delimiter"] == "."
+
+    def test_non_de_locale_not_affected(self):
+        """
+        For en_US the fix must not be applied, even when the values look like
+        de_DE conventions.
+        """
+        # Use a real locale-like mock returning en_US-style values.
+        ctx_manager, locale_patch = _mock_de_de_conventions(
+            decimal_delimiter=".",
+            group_delimiter=",",
+            grouping=[3, 3, 0],
+        )
+        with ctx_manager, locale_patch:
+            # "1,000.50" is en_US style.
+            result = infer_delimiters("1,000.50", "en_US")
+        # The function should infer the two delimiters from the text, not the
+        # de_DE override path.
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Regression: previously-working de_DE paths still work after the fix
+# ---------------------------------------------------------------------------
+
+
+class TestDeDERegressionPaths:
+    """Existing de_DE behavior must not regress after the grouping check."""
+
+    def test_integer_with_period_group_separator(self):
+        """'1.000' in de_DE means 1000 (integer with group separator)."""
+        ctx_manager, locale_patch = _mock_de_de_conventions()
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("1.000", "de_DE")
+        assert result is not None
+
+    def test_float_with_comma_decimal(self):
+        """'1.234,56' in de_DE means 1234.56."""
+        ctx_manager, locale_patch = _mock_de_de_conventions()
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("1.234,56", "de_DE")
+        assert result is not None
+        assert result["decimal_delimiter"] == ","
+        assert result["group_delimiter"] == "."
+
+    def test_bare_integer_no_delimiters(self):
+        """'12345' has no delimiters; result should have correct locale defaults."""
+        ctx_manager, locale_patch = _mock_de_de_conventions()
+        with ctx_manager, locale_patch:
+            result = infer_delimiters("12345", "de_DE")
+        assert result is not None
+        assert result["decimal_delimiter"] == ","
+        assert result["group_delimiter"] == "."

--- a/notes.md
+++ b/notes.md
@@ -1,7 +1,7 @@
 # LexNLP Dependency Modernization Notes
 
 Date: February 14, 2026
-Repo: `/Users/jackeames/Downloads/LexNLP`
+Repo: `/path/to/LexNLP`
 
 ## Objective
 
@@ -135,7 +135,7 @@ with two environment-sensitive issues. Both were fixed without adding skips/xfai
 Reliable full-validation flow on this machine:
 
 ```bash
-cd /Users/jackeames/Downloads/LexNLP
+cd /path/to/LexNLP
 
 # env
 uv venv --python 3.11 .venv
@@ -168,11 +168,11 @@ python3 ci/check_dist_contents.py
   contract-type prediction unreliable on modern runtimes.
 - Fix:
   - Added runtime model utilities in
-    `/Users/jackeames/Downloads/LexNLP/lexnlp/extract/en/contracts/runtime_model.py`
+    `/path/to/LexNLP/lexnlp/extract/en/contracts/runtime_model.py`
     to train/store a deterministic fallback model from
     `corpus/contract-types/0.1`.
   - Added
-    `/Users/jackeames/Downloads/LexNLP/scripts/train_contract_type_model.py`
+    `/path/to/LexNLP/scripts/train_contract_type_model.py`
     for explicit training/report generation.
   - Updated `ProbabilityPredictorContractType` to auto-fallback to
     `pipeline/contract-type/0.2-runtime` when legacy default loading fails and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,7 +40,6 @@ dependencies = [
   "dateparser==1.1.3",
   "elasticsearch>=8.5.0,<9",
   "gensim>=4.3.2,<5",
-  "importlib-metadata>=5.0.0; python_version < '3.10'",
   "joblib>=1.2.0,<2",
   "lxml>=4.9.1,<6",
   "nltk>=3.8.1,<3.9",

--- a/scripts/asset_drift_check.py
+++ b/scripts/asset_drift_check.py
@@ -108,7 +108,9 @@ def main(argv: Sequence[str]) -> int:
             else:
                 path = get_path_from_catalog(tag)
         except Exception as exc:
-            failures.append(f"{tag}: missing/unreadable ({exc})")
+            failures.append(
+                f"{tag}: missing/unreadable ({exc.__class__.__name__}: {exc})"
+            )
             continue
 
         if path.name != expected_name:
@@ -127,7 +129,7 @@ def main(argv: Sequence[str]) -> int:
                 continue
 
         actual_sha = sha256_file(path)
-        if actual_sha.lower() != expected_sha:
+        if actual_sha != expected_sha:
             failures.append(f"{tag}: sha256 mismatch {actual_sha} != {expected_sha}")
             continue
 

--- a/scripts/bootstrap_assets.py
+++ b/scripts/bootstrap_assets.py
@@ -10,6 +10,7 @@ import sys
 import zipfile
 from pathlib import Path
 from typing import Iterable, List, Sequence, Tuple
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 LOGGER = logging.getLogger("lexnlp.bootstrap")
@@ -201,6 +202,12 @@ def download_file(
         LOGGER.info("DRY RUN: would download %s -> %s", url, destination)
         return
 
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Refusing to fetch URL with unsupported scheme {parsed_url.scheme!r}: {url}"
+        )
+
     tmp_destination = destination.with_name(destination.name + ".part")
     if tmp_destination.exists():
         tmp_destination.unlink()
@@ -242,8 +249,30 @@ def extract_zip(archive_path: Path, destination_dir: Path, *, dry_run: bool) -> 
         LOGGER.info("DRY RUN: would extract %s -> %s", archive_path, destination_dir)
         return
     LOGGER.info("Extracting %s", archive_path)
+    destination_root = destination_dir.resolve()
+    destination_root.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(archive_path) as archive:
-        archive.extractall(destination_dir)
+        for member in archive.infolist():
+            member_path = (destination_root / member.filename).resolve()
+            # Protect against zip-slip: the resolved path must remain under
+            # the destination directory.
+            if (
+                member_path != destination_root
+                and destination_root not in member_path.parents
+            ):
+                raise RuntimeError(
+                    f"Refusing to extract zip member with unsafe path: {member.filename!r}"
+                )
+            if member.is_dir():
+                member_path.mkdir(parents=True, exist_ok=True)
+                continue
+            member_path.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as source, member_path.open("wb") as target:
+                while True:
+                    chunk = source.read(64 * 1024)
+                    if not chunk:
+                        break
+                    target.write(chunk)
 
 
 def bootstrap_stanford_assets(
@@ -408,9 +437,9 @@ def run_selected_tasks(args: argparse.Namespace) -> None:
         tasks.append(
             (
                 "contract-model",
-                lambda: bootstrap_contract_model(
+                lambda tag=contract_model_tag: bootstrap_contract_model(
                     dry_run=args.dry_run,
-                    tag=contract_model_tag,
+                    tag=tag,
                 ),
             )
         )
@@ -419,9 +448,9 @@ def run_selected_tasks(args: argparse.Namespace) -> None:
         tasks.append(
             (
                 "contract-type-model",
-                lambda: bootstrap_contract_type_model(
+                lambda tag=contract_type_model_tag: bootstrap_contract_type_model(
                     dry_run=args.dry_run,
-                    tag=contract_type_model_tag,
+                    tag=tag,
                 ),
             )
         )

--- a/scripts/contract_type_quality_gate.py
+++ b/scripts/contract_type_quality_gate.py
@@ -67,17 +67,17 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help="Maximum allowed candidate top-1 accuracy drop vs baseline.",
     )
     parser.add_argument(
-        "--max-accuracy-top3-regression",
-        type=float,
-        dest="max_accuracy_topn_regression",
-        default=None,
-        help="Deprecated alias for --max-accuracy-topn-regression (when --top-n=3).",
-    )
-    parser.add_argument(
         "--max-accuracy-topn-regression",
         type=float,
         default=0.0,
         help="Maximum allowed candidate top-N accuracy drop vs baseline.",
+    )
+    parser.add_argument(
+        "--max-accuracy-top3-regression",
+        type=float,
+        dest="max_accuracy_topn_regression",
+        default=0.0,
+        help="Deprecated alias for --max-accuracy-topn-regression (when --top-n=3).",
     )
     parser.add_argument(
         "--max-f1-macro-regression",
@@ -178,7 +178,7 @@ def score_pipeline(pipeline, texts: List[str], labels: List[str], *, top_n: int)
     classes = np.asarray(classes)
     top_indices = np.argsort(probas, axis=1)[:, -top_n:]
     hits = 0
-    for truth, indices in zip(labels, top_indices):
+    for truth, indices in zip(labels, top_indices, strict=True):
         if truth in set(classes[indices].tolist()):
             hits += 1
     accuracy_topn = float(hits / len(labels))

--- a/scripts/model_quality_gate.py
+++ b/scripts/model_quality_gate.py
@@ -22,7 +22,7 @@ def resolve_contract_model_tag() -> str:
     return (
         os.getenv("LEXNLP_CONTRACT_MODEL_TAG")
         or os.getenv("LEXNLP_IS_CONTRACT_MODEL_TAG")
-        or "pipeline/is-contract/0.1"
+        or "pipeline/is-contract/0.2"
     ).strip()
 
 

--- a/scripts/reexport_bundled_sklearn_models.py
+++ b/scripts/reexport_bundled_sklearn_models.py
@@ -67,7 +67,7 @@ def load_model(path: Path):
         with path.open("rb") as f:
             try:
                 return renamed_load(f)
-            except Exception:
+            except (pickle.UnpicklingError, ValueError, KeyError):
                 # If the file was previously dumped with joblib, fall back so we
                 # can re-export it into a plain pickle again.
                 return joblib.load(path)
@@ -91,13 +91,18 @@ def reexport_layered_definition_models(path: Path) -> None:
     if tmp_path.exists():
         tmp_path.unlink()
 
-    with ZipFile(tmp_path, mode="w", compression=ZIP_STORED) as archive:
-        for name in ("term.pickle", "definition.pickle"):
-            archive.writestr(
-                name,
-                pickle.dumps(payload[name], protocol=pickle.HIGHEST_PROTOCOL),
-            )
-    tmp_path.replace(path)
+    try:
+        with ZipFile(tmp_path, mode="w", compression=ZIP_STORED) as archive:
+            for name in ("term.pickle", "definition.pickle"):
+                archive.writestr(
+                    name,
+                    pickle.dumps(payload[name], protocol=pickle.HIGHEST_PROTOCOL),
+                )
+        tmp_path.replace(path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
 
 
 def legacy_warning_count_for_load(path: Path) -> int:

--- a/scripts/reexport_contract_model.py
+++ b/scripts/reexport_contract_model.py
@@ -155,7 +155,16 @@ def run_quality_gate(
     if baseline_metrics_json.exists():
         cmd.extend(["--baseline-metrics-json", str(baseline_metrics_json)])
 
-    subprocess.run(cmd, check=True)
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr_text = exc.stderr or ""
+        stdout_text = exc.stdout or ""
+        if stdout_text:
+            sys.stdout.write(stdout_text)
+        if stderr_text:
+            sys.stderr.write(stderr_text)
+        raise
 
 
 def get_legacy_warning_messages(model_path: Path) -> list[str]:
@@ -164,21 +173,26 @@ import json
 import sys
 import warnings
 from pathlib import Path
-from cloudpickle import load
 
 token = sys.argv[2]
 path = Path(sys.argv[1])
-with warnings.catch_warnings(record=True) as captured:
-    warnings.simplefilter("always")
-    with path.open("rb") as model_file:
-        load(model_file)
+try:
+    from cloudpickle import load
 
-messages = [
-    str(item.message).splitlines()[0]
-    for item in captured
-    if token in str(item.message)
-]
-print(json.dumps(messages))
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        with path.open("rb") as model_file:
+            load(model_file)
+
+    messages = [
+        str(item.message).splitlines()[0]
+        for item in captured
+        if token in str(item.message)
+    ]
+    print(json.dumps(messages))
+except Exception as exc:  # noqa: BLE001
+    print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}))
+    sys.exit(1)
 """
     result = subprocess.run(
         [sys.executable, "-c", probe_code, str(model_path), LEGACY_WARNING_TOKEN],

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,6 @@
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"

--- a/scripts/tests/test_asset_drift_check.py
+++ b/scripts/tests/test_asset_drift_check.py
@@ -1,0 +1,273 @@
+"""Tests for scripts/asset_drift_check.py.
+
+Covers changes introduced in the PR:
+  - Error message format now includes exc.__class__.__name__
+  - SHA256 comparison: actual_sha is NOT lowercased; expected_sha is lowercased
+    in load_manifest — a mismatch is now caught correctly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the scripts package importable.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import asset_drift_check  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(path: Path, assets: list) -> None:
+    path.write_text(json.dumps({"assets": assets}), encoding="utf-8")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Error message format: exc.__class__.__name__ included
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessageFormat:
+    """main() failure entries should include the exception class name."""
+
+    def test_missing_tag_error_includes_class_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When catalog lookup raises FileNotFoundError the entry must name the class."""
+        manifest_path = tmp_path / "manifest.json"
+        _write_manifest(
+            manifest_path,
+            [{"tag": "pipeline/missing/0.1", "filename": "model.pkl", "sha256": "abc123"}],
+        )
+
+        def fake_get_path(tag: str) -> Path:
+            raise FileNotFoundError(f"tag not found: {tag}")
+
+        monkeypatch.setattr(
+            "asset_drift_check.get_path_from_catalog",
+            fake_get_path,
+            raising=False,
+        )
+
+        # Patch the import inside main as well (it does a local import).
+        import unittest.mock as mock
+
+        catalog_mod_mock = mock.MagicMock()
+        catalog_mod_mock.get_path_from_catalog = fake_get_path
+
+        dl_mock = mock.MagicMock()
+        dl_mock.download_github_release = mock.MagicMock(
+            side_effect=FileNotFoundError("release not found")
+        )
+
+        with mock.patch.dict(
+            "sys.modules",
+            {
+                "lexnlp.ml.catalog": catalog_mod_mock,
+                "lexnlp.ml.catalog.download": dl_mock,
+            },
+        ):
+            import io, contextlib
+
+            stderr_capture = io.StringIO()
+            with contextlib.redirect_stderr(stderr_capture):
+                rc = asset_drift_check.main(["--manifest", str(manifest_path)])
+
+        assert rc == 1
+        stderr_out = stderr_capture.getvalue()
+        # The failure message must include the exception class name.
+        assert "FileNotFoundError" in stderr_out or "Error" in stderr_out
+
+    def test_error_message_includes_class_name_directly(self) -> None:
+        """
+        Unit-test the failure-message format expression directly.
+
+        The PR changed the format from:
+            f"{tag}: missing/unreadable ({exc})"
+        to:
+            f"{tag}: missing/unreadable ({exc.__class__.__name__}: {exc})"
+        """
+        exc = FileNotFoundError("tag not found: pipeline/x/0.1")
+        tag = "pipeline/x/0.1"
+        # Reproduce the exact format used in asset_drift_check.main
+        message = f"{tag}: missing/unreadable ({exc.__class__.__name__}: {exc})"
+        assert "FileNotFoundError" in message
+        assert "pipeline/x/0.1" in message
+
+    def test_error_message_format_for_value_error(self) -> None:
+        """ValueError class name should also appear in the formatted message."""
+        exc = ValueError("bad data")
+        tag = "pipeline/test/0.1"
+        message = f"{tag}: missing/unreadable ({exc.__class__.__name__}: {exc})"
+        assert "ValueError" in message
+        assert "bad data" in message
+
+
+# ---------------------------------------------------------------------------
+# SHA256 comparison: exact-case matching
+# ---------------------------------------------------------------------------
+
+
+class TestSha256Comparison:
+    """
+    Before the fix: actual_sha was lowercased before comparison.
+    After the fix: actual_sha is used verbatim; expected_sha is pre-lowercased.
+    sha256.hexdigest() always returns lowercase, so valid manifests still pass.
+    """
+
+    def test_lowercase_sha_matches(self, tmp_path: Path) -> None:
+        """Lowercase SHA256 in manifest matches hexdigest output."""
+        data = b"model data"
+        sha = _sha256_bytes(data)
+        assert sha == sha.lower(), "hexdigest must already be lowercase"
+
+        model_file = tmp_path / "model.pkl"
+        model_file.write_bytes(data)
+
+        actual = asset_drift_check.sha256_file(model_file)
+        assert actual == sha  # exact match, no casing issue
+
+    def test_uppercase_sha_in_manifest_does_not_match(self, tmp_path: Path) -> None:
+        """
+        If a manifest entry has an uppercase SHA (non-canonical), it won't match
+        the hexdigest — this tests the exact comparison semantics.
+
+        expected_sha = asset["sha256"].strip().lower()  <-- always lower in main()
+        actual_sha   = sha256_file(path)                <-- always lower from hexdigest
+
+        So the comparison is lowercase vs lowercase: they SHOULD match for a valid file.
+        This test verifies sha256_file returns lowercase always.
+        """
+        data = b"some bytes"
+        model_file = tmp_path / "model.pkl"
+        model_file.write_bytes(data)
+
+        actual = asset_drift_check.sha256_file(model_file)
+        assert actual == actual.lower(), "sha256_file must return lowercase hex"
+
+    def test_sha_mismatch_is_detected(self, tmp_path: Path) -> None:
+        """A file whose actual SHA differs from the manifest entry is a failure."""
+        manifest_path = tmp_path / "manifest.json"
+        model_file = tmp_path / "model.pkl"
+        model_file.write_bytes(b"correct content")
+        correct_sha = _sha256_bytes(b"correct content")
+        wrong_sha = _sha256_bytes(b"different content")
+
+        _write_manifest(
+            manifest_path,
+            [
+                {
+                    "tag": "pipeline/test/0.1",
+                    "filename": "model.pkl",
+                    "sha256": wrong_sha,
+                }
+            ],
+        )
+
+        import unittest.mock as mock
+
+        catalog_mock = mock.MagicMock()
+        catalog_mock.get_path_from_catalog = mock.MagicMock(return_value=model_file)
+
+        dl_mock = mock.MagicMock()
+
+        with mock.patch.dict(
+            "sys.modules",
+            {
+                "lexnlp.ml.catalog": catalog_mock,
+                "lexnlp.ml.catalog.download": dl_mock,
+            },
+        ):
+            import io, contextlib
+
+            stderr_capture = io.StringIO()
+            with contextlib.redirect_stderr(stderr_capture):
+                rc = asset_drift_check.main(["--manifest", str(manifest_path)])
+
+        assert rc == 1
+        assert "sha256 mismatch" in stderr_capture.getvalue()
+        # The actual SHA should be present verbatim (lowercase from hexdigest).
+        assert correct_sha in stderr_capture.getvalue()
+
+    def test_sha_match_succeeds(self, tmp_path: Path) -> None:
+        """A file whose SHA matches the manifest entry passes."""
+        data = b"model payload"
+        model_file = tmp_path / "model.pkl"
+        model_file.write_bytes(data)
+        sha = _sha256_bytes(data)
+
+        manifest_path = tmp_path / "manifest.json"
+        _write_manifest(
+            manifest_path,
+            [
+                {
+                    "tag": "pipeline/test/0.1",
+                    "filename": "model.pkl",
+                    "sha256": sha,
+                }
+            ],
+        )
+
+        import unittest.mock as mock
+
+        catalog_mock = mock.MagicMock()
+        catalog_mock.get_path_from_catalog = mock.MagicMock(return_value=model_file)
+
+        dl_mock = mock.MagicMock()
+
+        with mock.patch.dict(
+            "sys.modules",
+            {
+                "lexnlp.ml.catalog": catalog_mock,
+                "lexnlp.ml.catalog.download": dl_mock,
+            },
+        ):
+            rc = asset_drift_check.main(["--manifest", str(manifest_path)])
+
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# load_manifest – basic validation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifest:
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            asset_drift_check.load_manifest(tmp_path / "nonexistent.json")
+
+    def test_non_dict_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(ValueError, match="object"):
+            asset_drift_check.load_manifest(path)
+
+    def test_empty_assets_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"assets": []}), encoding="utf-8")
+        with pytest.raises(ValueError, match="non-empty"):
+            asset_drift_check.load_manifest(path)
+
+    def test_valid_manifest_returns_payload(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        payload = {"assets": [{"tag": "t", "filename": "f", "sha256": "s"}]}
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        result = asset_drift_check.load_manifest(path)
+        assert result["assets"][0]["tag"] == "t"

--- a/scripts/tests/test_bootstrap_assets.py
+++ b/scripts/tests/test_bootstrap_assets.py
@@ -1,0 +1,339 @@
+"""Tests for scripts/bootstrap_assets.py.
+
+Covers changes introduced in the PR:
+  - download_file: URL scheme validation (only http/https allowed)
+  - extract_zip: zip-slip protection
+  - run_selected_tasks: lambda closure fix for contract_model_tag /
+    contract_type_model_tag
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+from typing import Sequence
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the scripts package importable from within the test suite.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import bootstrap_assets  # noqa: E402  (module-level import after sys.path tweak)
+
+
+# ---------------------------------------------------------------------------
+# download_file – URL scheme validation
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadFileSchemeValidation:
+    """URL scheme guard introduced in this PR."""
+
+    def test_http_scheme_proceeds_to_download(self, tmp_path: Path) -> None:
+        """http:// URLs must pass the scheme check and attempt an actual download."""
+        destination = tmp_path / "out.zip"
+        with patch("bootstrap_assets.urlopen") as mock_urlopen:
+            mock_response = io.BytesIO(b"data")
+            mock_response.__enter__ = lambda s: s  # type: ignore[attr-defined]
+            mock_response.__exit__ = lambda *a: None  # type: ignore[attr-defined]
+            mock_urlopen.return_value = mock_response
+            # Should not raise; urlopen is expected to be called.
+            # We can't easily let the full flow complete without network, so
+            # we patch urlopen to raise a controlled error after the check.
+            mock_urlopen.side_effect = OSError("no network")
+            with pytest.raises(OSError, match="no network"):
+                bootstrap_assets.download_file(
+                    "http://example.com/file.zip",
+                    destination,
+                    force=True,
+                    dry_run=False,
+                    timeout=5,
+                )
+            # Crucially: no ValueError was raised first.
+
+    def test_https_scheme_proceeds_to_download(self, tmp_path: Path) -> None:
+        """https:// URLs must pass the scheme check."""
+        destination = tmp_path / "out.zip"
+        with patch("bootstrap_assets.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = OSError("no network")
+            with pytest.raises(OSError, match="no network"):
+                bootstrap_assets.download_file(
+                    "https://example.com/file.zip",
+                    destination,
+                    force=True,
+                    dry_run=False,
+                    timeout=5,
+                )
+
+    def test_ftp_scheme_raises_value_error(self, tmp_path: Path) -> None:
+        """ftp:// URLs must be rejected before any network call."""
+        destination = tmp_path / "out.zip"
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            bootstrap_assets.download_file(
+                "ftp://example.com/file.zip",
+                destination,
+                force=True,
+                dry_run=False,
+                timeout=5,
+            )
+
+    def test_file_scheme_raises_value_error(self, tmp_path: Path) -> None:
+        """file:// URLs must be rejected."""
+        destination = tmp_path / "out.zip"
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            bootstrap_assets.download_file(
+                "file:///etc/passwd",
+                destination,
+                force=True,
+                dry_run=False,
+                timeout=5,
+            )
+
+    def test_scheme_error_message_contains_scheme_and_url(self, tmp_path: Path) -> None:
+        """ValueError message should name the offending scheme."""
+        destination = tmp_path / "out.zip"
+        with pytest.raises(ValueError, match="'ftp'"):
+            bootstrap_assets.download_file(
+                "ftp://example.com/resource",
+                destination,
+                force=True,
+                dry_run=False,
+                timeout=5,
+            )
+
+    def test_dry_run_skips_scheme_check(self, tmp_path: Path) -> None:
+        """In dry-run mode the scheme check is not reached; no error expected."""
+        destination = tmp_path / "out.zip"
+        # dry_run=True logs and returns before the scheme check – no error.
+        bootstrap_assets.download_file(
+            "ftp://example.com/file.zip",
+            destination,
+            force=True,
+            dry_run=True,
+            timeout=5,
+        )
+
+    def test_existing_destination_skips_scheme_check_when_not_forced(
+        self, tmp_path: Path
+    ) -> None:
+        """When destination already exists and force=False, skip before scheme check."""
+        destination = tmp_path / "out.zip"
+        destination.write_bytes(b"existing")
+        # No error even for an invalid URL scheme because the function returns early.
+        bootstrap_assets.download_file(
+            "ftp://example.com/file.zip",
+            destination,
+            force=False,
+            dry_run=False,
+            timeout=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# extract_zip – zip-slip protection
+# ---------------------------------------------------------------------------
+
+
+def _make_zip(members: dict[str, bytes]) -> bytes:
+    """Build an in-memory ZIP archive with the given {filename: content} mapping."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+class TestExtractZipSlipProtection:
+    """Zip-slip guard introduced in this PR."""
+
+    def test_safe_members_extracted_correctly(self, tmp_path: Path) -> None:
+        """Normal archive members are extracted to the correct location."""
+        archive_bytes = _make_zip(
+            {
+                "subdir/file.txt": b"hello",
+                "toplevel.txt": b"world",
+            }
+        )
+        archive_path = tmp_path / "archive.zip"
+        archive_path.write_bytes(archive_bytes)
+        dest = tmp_path / "out"
+
+        bootstrap_assets.extract_zip(archive_path, dest, dry_run=False)
+
+        assert (dest / "subdir" / "file.txt").read_bytes() == b"hello"
+        assert (dest / "toplevel.txt").read_bytes() == b"world"
+
+    def test_path_traversal_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Members whose resolved path escapes the destination raise RuntimeError."""
+        archive_bytes = _make_zip({"../escape.txt": b"evil"})
+        archive_path = tmp_path / "evil.zip"
+        archive_path.write_bytes(archive_bytes)
+        dest = tmp_path / "out"
+
+        with pytest.raises(RuntimeError, match="unsafe path"):
+            bootstrap_assets.extract_zip(archive_path, dest, dry_run=False)
+
+    def test_absolute_path_member_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Absolute-path member names that resolve outside the destination are rejected."""
+        # Build a zip with an absolute-path member using a raw ZipInfo.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo("/tmp/absolute.txt")
+            zf.writestr(info, b"evil")
+        archive_path = tmp_path / "abs.zip"
+        archive_path.write_bytes(buf.getvalue())
+        dest = tmp_path / "out"
+
+        with pytest.raises(RuntimeError, match="unsafe path"):
+            bootstrap_assets.extract_zip(archive_path, dest, dry_run=False)
+
+    def test_deep_traversal_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Deep path-traversal sequences are also caught."""
+        archive_bytes = _make_zip({"a/b/../../../../../../etc/passwd": b"evil"})
+        archive_path = tmp_path / "deep.zip"
+        archive_path.write_bytes(archive_bytes)
+        dest = tmp_path / "out"
+
+        with pytest.raises(RuntimeError, match="unsafe path"):
+            bootstrap_assets.extract_zip(archive_path, dest, dry_run=False)
+
+    def test_dry_run_does_not_extract(self, tmp_path: Path) -> None:
+        """dry_run=True must not create any files."""
+        archive_bytes = _make_zip({"file.txt": b"data"})
+        archive_path = tmp_path / "archive.zip"
+        archive_path.write_bytes(archive_bytes)
+        dest = tmp_path / "out"
+
+        bootstrap_assets.extract_zip(archive_path, dest, dry_run=True)
+
+        assert not dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Lambda closure fix in run_selected_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestLambdaClosureFix:
+    """
+    Before the fix, both lambda callbacks captured the loop variables by
+    reference, meaning every callback used the *last* value assigned to
+    contract_model_tag / contract_type_model_tag.  After the fix each
+    lambda binds the tag value at construction time via a default argument.
+    """
+
+    def _make_args(
+        self,
+        *,
+        dry_run: bool = True,
+        all_tasks: bool = False,
+        contract_model: bool = False,
+        contract_type_model: bool = False,
+    ) -> "bootstrap_assets.argparse.Namespace":
+        import argparse
+
+        ns = argparse.Namespace(
+            nltk=False,
+            contract_model=contract_model,
+            contract_type_model=contract_type_model,
+            stanford=False,
+            tika=False,
+            all=all_tasks,
+            dry_run=dry_run,
+            force=False,
+            timeout=30,
+            stanford_dir=str(bootstrap_assets.DEFAULT_STANFORD_DIR),
+            tika_dir=str(bootstrap_assets.DEFAULT_TIKA_DIR),
+            verbose=False,
+        )
+        return ns
+
+    def test_contract_model_lambda_captures_tag_at_construction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The lambda for contract-model task must capture the tag resolved
+        at task-list construction time, not any later mutation.
+        """
+        captured_tags: list[str] = []
+
+        def fake_bootstrap_contract_model(*, dry_run: bool, tag: str) -> None:
+            captured_tags.append(tag)
+
+        monkeypatch.setattr(
+            bootstrap_assets, "bootstrap_contract_model", fake_bootstrap_contract_model
+        )
+        monkeypatch.setattr(
+            bootstrap_assets,
+            "resolve_contract_model_tag",
+            lambda: "pipeline/is-contract/TEST-TAG",
+        )
+
+        args = self._make_args(contract_model=True)
+        bootstrap_assets.run_selected_tasks(args)
+
+        assert captured_tags == ["pipeline/is-contract/TEST-TAG"]
+
+    def test_contract_type_model_lambda_captures_tag_at_construction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The lambda for contract-type-model task must capture the tag resolved
+        at task-list construction time.
+        """
+        captured_tags: list[str] = []
+
+        def fake_bootstrap_contract_type_model(*, dry_run: bool, tag: str) -> None:
+            captured_tags.append(tag)
+
+        monkeypatch.setattr(
+            bootstrap_assets,
+            "bootstrap_contract_type_model",
+            fake_bootstrap_contract_type_model,
+        )
+        monkeypatch.setattr(
+            bootstrap_assets,
+            "resolve_contract_type_model_tag",
+            lambda: "pipeline/contract-type/TEST-TAG",
+        )
+
+        args = self._make_args(contract_type_model=True)
+        bootstrap_assets.run_selected_tasks(args)
+
+        assert captured_tags == ["pipeline/contract-type/TEST-TAG"]
+
+    def test_both_lambdas_capture_independent_tags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both tasks are scheduled they each use their own tag."""
+        captured: list[tuple[str, str]] = []
+
+        def fake_contract_model(*, dry_run: bool, tag: str) -> None:
+            captured.append(("contract-model", tag))
+
+        def fake_contract_type_model(*, dry_run: bool, tag: str) -> None:
+            captured.append(("contract-type-model", tag))
+
+        monkeypatch.setattr(bootstrap_assets, "bootstrap_contract_model", fake_contract_model)
+        monkeypatch.setattr(
+            bootstrap_assets, "bootstrap_contract_type_model", fake_contract_type_model
+        )
+        monkeypatch.setattr(
+            bootstrap_assets, "resolve_contract_model_tag", lambda: "tag-contract"
+        )
+        monkeypatch.setattr(
+            bootstrap_assets, "resolve_contract_type_model_tag", lambda: "tag-contract-type"
+        )
+
+        args = self._make_args(contract_model=True, contract_type_model=True)
+        bootstrap_assets.run_selected_tasks(args)
+
+        assert ("contract-model", "tag-contract") in captured
+        assert ("contract-type-model", "tag-contract-type") in captured

--- a/scripts/tests/test_contract_type_quality_gate.py
+++ b/scripts/tests/test_contract_type_quality_gate.py
@@ -1,0 +1,270 @@
+"""Tests for scripts/contract_type_quality_gate.py.
+
+Covers changes introduced in the PR:
+  - parse_args: --max-accuracy-topn-regression and --max-accuracy-top3-regression
+    argument order / dest swap (both map to max_accuracy_topn_regression).
+  - score_pipeline: zip(..., strict=True) raises ValueError on length mismatch.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the scripts package importable.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import contract_type_quality_gate  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_args – argument mapping
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    """Verify that both CLI argument names map to max_accuracy_topn_regression."""
+
+    def test_max_accuracy_topn_regression_flag(self) -> None:
+        args = contract_type_quality_gate.parse_args(
+            ["--candidate-tag", "t", "--max-accuracy-topn-regression", "0.05"]
+        )
+        assert args.max_accuracy_topn_regression == pytest.approx(0.05)
+
+    def test_max_accuracy_top3_regression_deprecated_alias(self) -> None:
+        """--max-accuracy-top3-regression is a deprecated alias that sets the same dest."""
+        args = contract_type_quality_gate.parse_args(
+            ["--candidate-tag", "t", "--max-accuracy-top3-regression", "0.07"]
+        )
+        assert args.max_accuracy_topn_regression == pytest.approx(0.07)
+
+    def test_both_flags_last_one_wins(self) -> None:
+        """When both flags are given, argparse uses the last value."""
+        args = contract_type_quality_gate.parse_args(
+            [
+                "--candidate-tag",
+                "t",
+                "--max-accuracy-topn-regression",
+                "0.01",
+                "--max-accuracy-top3-regression",
+                "0.09",
+            ]
+        )
+        # Both map to the same dest; last value on command line wins.
+        assert args.max_accuracy_topn_regression == pytest.approx(0.09)
+
+    def test_defaults_are_zero(self) -> None:
+        args = contract_type_quality_gate.parse_args(["--candidate-tag", "t"])
+        assert args.max_accuracy_topn_regression == pytest.approx(0.0)
+        assert args.max_accuracy_top1_regression == pytest.approx(0.0)
+        assert args.max_f1_macro_regression == pytest.approx(0.0)
+        assert args.max_f1_weighted_regression == pytest.approx(0.0)
+
+    def test_candidate_tag_required(self) -> None:
+        with pytest.raises(SystemExit):
+            contract_type_quality_gate.parse_args([])
+
+    def test_top_n_default(self) -> None:
+        args = contract_type_quality_gate.parse_args(["--candidate-tag", "t"])
+        assert args.top_n == 3
+
+
+# ---------------------------------------------------------------------------
+# score_pipeline – zip strict=True
+# ---------------------------------------------------------------------------
+
+
+class _DummyPipeline:
+    """Minimal sklearn-like pipeline stub."""
+
+    def __init__(self, classes: List[str], top1_predictions: List[str], probas: np.ndarray):
+        self._classes = classes
+        self._top1 = top1_predictions
+        self._probas = probas
+        self.classes_ = classes
+
+    def predict(self, texts):
+        return self._top1
+
+    def predict_proba(self, texts):
+        return self._probas
+
+
+class TestScorePipeline:
+    def _make_pipeline(
+        self, n: int = 4, n_classes: int = 3
+    ) -> tuple[_DummyPipeline, List[str], List[str]]:
+        rng = np.random.default_rng(42)
+        classes = [f"class_{i}" for i in range(n_classes)]
+        labels = [classes[i % n_classes] for i in range(n)]
+        probas = rng.dirichlet(np.ones(n_classes), size=n)
+        pipeline = _DummyPipeline(classes, labels, probas)
+        return pipeline, labels, classes
+
+    def test_returns_all_required_metrics(self) -> None:
+        pipeline, labels, _ = self._make_pipeline(n=6, n_classes=2)
+        texts = [f"doc {i}" for i in range(len(labels))]
+        result = contract_type_quality_gate.score_pipeline(pipeline, texts, labels, top_n=2)
+        assert set(result.keys()) == {
+            "accuracy_top1",
+            "accuracy_topn",
+            "f1_macro",
+            "f1_weighted",
+        }
+
+    def test_perfect_predictions(self) -> None:
+        classes = ["A", "B", "C"]
+        labels = ["A", "B", "C", "A"]
+        # probas: each row has 1.0 for the true class
+        probas = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+        pipeline = _DummyPipeline(classes, labels, probas)
+        texts = ["t1", "t2", "t3", "t4"]
+        result = contract_type_quality_gate.score_pipeline(pipeline, texts, labels, top_n=1)
+        assert result["accuracy_top1"] == pytest.approx(1.0)
+        assert result["accuracy_topn"] == pytest.approx(1.0)
+
+    def test_top_n_larger_than_n_classes_clips_to_n_classes(self) -> None:
+        """top_n > number of classes still works (argsort selects all)."""
+        classes = ["A", "B"]
+        labels = ["A", "B"]
+        probas = np.array([[0.9, 0.1], [0.2, 0.8]])
+        pipeline = _DummyPipeline(classes, labels, probas)
+        texts = ["t1", "t2"]
+        # No exception expected.
+        result = contract_type_quality_gate.score_pipeline(pipeline, texts, labels, top_n=10)
+        assert "accuracy_topn" in result
+
+    def test_strict_zip_raises_on_mismatched_lengths(self) -> None:
+        """
+        After the fix, zip(labels, top_indices, strict=True) should raise
+        ValueError when labels and top_indices have different lengths.
+
+        We trigger this by monkeypatching predict_proba to return a
+        shorter array than the number of labels.
+        """
+        classes = ["A", "B"]
+        labels = ["A", "B", "A"]  # 3 labels
+        probas_short = np.array([[0.9, 0.1], [0.2, 0.8]])  # only 2 rows
+
+        pipeline = _DummyPipeline(classes, labels[:2], probas_short)
+        # Override predict to return all 3 labels (consistent with len(texts))
+        pipeline._top1 = labels  # type: ignore[attr-defined]
+        texts = ["t1", "t2", "t3"]
+
+        with pytest.raises(ValueError):
+            contract_type_quality_gate.score_pipeline(pipeline, texts, labels, top_n=1)
+
+    def test_pipeline_without_predict_proba_raises(self) -> None:
+        """Pipeline missing predict_proba raises ValueError."""
+
+        class NoProbaPipeline:
+            classes_ = ["A", "B"]
+
+            def predict(self, texts):
+                return texts
+
+        with pytest.raises(ValueError, match="predict_proba"):
+            contract_type_quality_gate.score_pipeline(
+                NoProbaPipeline(), ["t1"], ["A"], top_n=1
+            )
+
+    def test_pipeline_without_classes_raises(self) -> None:
+        """Pipeline missing classes_ raises ValueError."""
+        probas = np.array([[0.6, 0.4]])
+        pipeline = MagicMock()
+        pipeline.predict.return_value = ["A"]
+        pipeline.predict_proba.return_value = probas
+        del pipeline.classes_  # Remove the attribute
+
+        with pytest.raises((ValueError, AttributeError)):
+            contract_type_quality_gate.score_pipeline(pipeline, ["t"], ["A"], top_n=1)
+
+
+# ---------------------------------------------------------------------------
+# parse_metrics – backward compatibility with accuracy_top3
+# ---------------------------------------------------------------------------
+
+
+class TestParseMetrics:
+    def test_accuracy_top3_backwards_compat(self) -> None:
+        raw = {
+            "accuracy_top1": 0.8,
+            "accuracy_top3": 0.9,
+            "f1_macro": 0.75,
+            "f1_weighted": 0.76,
+        }
+        result = contract_type_quality_gate.parse_metrics(raw, "test")
+        assert "accuracy_topn" in result
+        assert result["accuracy_topn"] == pytest.approx(0.9)
+
+    def test_missing_key_raises(self) -> None:
+        raw = {
+            "accuracy_top1": 0.8,
+            # accuracy_topn missing
+            "f1_macro": 0.75,
+            "f1_weighted": 0.76,
+        }
+        with pytest.raises(ValueError, match="accuracy_topn"):
+            contract_type_quality_gate.parse_metrics(raw, "test")
+
+
+# ---------------------------------------------------------------------------
+# load_fixture
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFixture:
+    def _write_fixture(self, path: Path, rows: list[dict]) -> None:
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["Text", "Contract_Type"])
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def test_valid_fixture_loads(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fix.csv"
+        self._write_fixture(
+            fixture,
+            [{"Text": "sample contract", "Contract_Type": "NDA"}],
+        )
+        texts, labels = contract_type_quality_gate.load_fixture(fixture)
+        assert texts == ["sample contract"]
+        assert labels == ["NDA"]
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            contract_type_quality_gate.load_fixture(tmp_path / "no_file.csv")
+
+    def test_missing_text_column_raises(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fix.csv"
+        with fixture.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["Text", "Contract_Type"])
+            writer.writeheader()
+            writer.writerow({"Text": "", "Contract_Type": "NDA"})
+        with pytest.raises(ValueError, match="missing Text"):
+            contract_type_quality_gate.load_fixture(fixture)
+
+    def test_missing_label_column_raises(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fix.csv"
+        with fixture.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["Text", "Contract_Type"])
+            writer.writeheader()
+            writer.writerow({"Text": "some text", "Contract_Type": ""})
+        with pytest.raises(ValueError, match="missing Contract_Type"):
+            contract_type_quality_gate.load_fixture(fixture)

--- a/scripts/tests/test_reexport_bundled_sklearn_models.py
+++ b/scripts/tests/test_reexport_bundled_sklearn_models.py
@@ -1,0 +1,291 @@
+"""Tests for scripts/reexport_bundled_sklearn_models.py.
+
+Covers changes introduced in the PR:
+  - load_model: catches (pickle.UnpicklingError, ValueError, KeyError) instead
+    of bare Exception for the addresses_clf.pickle fallback.
+  - reexport_layered_definition_models: try/finally ensures tmp_path is cleaned
+    up on exception.
+"""
+
+from __future__ import annotations
+
+import io
+import pickle
+import sys
+from pathlib import Path
+from zipfile import ZipFile, ZIP_STORED
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the scripts package importable.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import reexport_bundled_sklearn_models as script_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_layered_zip(term_obj: object, definition_obj: object) -> bytes:
+    """Build an in-memory zip with term.pickle and definition.pickle entries."""
+    buf = io.BytesIO()
+    with ZipFile(buf, "w", compression=ZIP_STORED) as zf:
+        zf.writestr("term.pickle", pickle.dumps(term_obj, protocol=pickle.HIGHEST_PROTOCOL))
+        zf.writestr(
+            "definition.pickle", pickle.dumps(definition_obj, protocol=pickle.HIGHEST_PROTOCOL)
+        )
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# load_model: narrowed exception handling for addresses_clf.pickle
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModelExceptionNarrowing:
+    """
+    load_model catches (pickle.UnpicklingError, ValueError, KeyError) for
+    addresses_clf.pickle.  Other exceptions must propagate.
+    """
+
+    def test_unpickling_error_falls_back_to_joblib(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pickle.UnpicklingError triggers the joblib fallback."""
+        fake_model = {"model": "data"}
+        addr_clf = tmp_path / "addresses_clf.pickle"
+        # Write a joblib-style dump so joblib.load succeeds.
+        import joblib
+        joblib.dump(fake_model, addr_clf)
+
+        def failing_renamed_load(_f):
+            raise pickle.UnpicklingError("bad pickle")
+
+        import lexnlp.utils.unpickler as unpickler_mod
+        monkeypatch.setattr(unpickler_mod, "renamed_load", failing_renamed_load)
+
+        result = script_mod.load_model(addr_clf)
+        assert result == fake_model
+
+    def test_value_error_falls_back_to_joblib(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ValueError triggers the joblib fallback."""
+        fake_model = {"v": 42}
+        addr_clf = tmp_path / "addresses_clf.pickle"
+        import joblib
+        joblib.dump(fake_model, addr_clf)
+
+        def failing_renamed_load(_f):
+            raise ValueError("version mismatch")
+
+        import lexnlp.utils.unpickler as unpickler_mod
+        monkeypatch.setattr(unpickler_mod, "renamed_load", failing_renamed_load)
+
+        result = script_mod.load_model(addr_clf)
+        assert result == fake_model
+
+    def test_key_error_falls_back_to_joblib(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """KeyError triggers the joblib fallback."""
+        fake_model = {"k": "v"}
+        addr_clf = tmp_path / "addresses_clf.pickle"
+        import joblib
+        joblib.dump(fake_model, addr_clf)
+
+        def failing_renamed_load(_f):
+            raise KeyError("missing_module")
+
+        import lexnlp.utils.unpickler as unpickler_mod
+        monkeypatch.setattr(unpickler_mod, "renamed_load", failing_renamed_load)
+
+        result = script_mod.load_model(addr_clf)
+        assert result == fake_model
+
+    def test_other_exception_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Exceptions OTHER than (UnpicklingError, ValueError, KeyError) must NOT
+        be swallowed — they should propagate to the caller.
+        """
+        addr_clf = tmp_path / "addresses_clf.pickle"
+        addr_clf.write_bytes(b"irrelevant")
+
+        def exploding_renamed_load(_f):
+            raise RuntimeError("unexpected infrastructure error")
+
+        import lexnlp.utils.unpickler as unpickler_mod
+        monkeypatch.setattr(unpickler_mod, "renamed_load", exploding_renamed_load)
+
+        with pytest.raises(RuntimeError, match="unexpected infrastructure error"):
+            script_mod.load_model(addr_clf)
+
+    def test_non_addresses_model_uses_joblib_directly(
+        self, tmp_path: Path
+    ) -> None:
+        """For non-addresses_clf.pickle files, joblib.load is called directly."""
+        fake_model = {"type": "segmenter"}
+        model_path = tmp_path / "section_segmenter.pickle"
+        import joblib
+        joblib.dump(fake_model, model_path)
+
+        result = script_mod.load_model(model_path)
+        assert result == fake_model
+
+
+# ---------------------------------------------------------------------------
+# reexport_layered_definition_models: tmp cleanup on exception
+# ---------------------------------------------------------------------------
+
+
+class TestReexportLayeredDefinitionModelsTmpCleanup:
+    """
+    reexport_layered_definition_models must delete the .part temp file
+    if an exception occurs during the ZipFile write phase.
+    """
+
+    def test_tmp_file_cleaned_up_on_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        When ZipFile.writestr raises, the .part file must not be left behind.
+        """
+        # Create a valid layered model zip so load succeeds.
+        payload_zip = _make_layered_zip(
+            term_obj={"term": "data"},
+            definition_obj={"def": "data"},
+        )
+        model_path = tmp_path / "definition_model_layered.pickle.gzip"
+        model_path.write_bytes(payload_zip)
+
+        # Patch load_layered_definition_models to succeed.
+        fake_payload = {
+            "term.pickle": {"term": "data"},
+            "definition.pickle": {"def": "data"},
+        }
+        monkeypatch.setattr(
+            script_mod, "load_layered_definition_models", lambda _p: fake_payload
+        )
+
+        # Patch pickle.dumps to raise during the write loop.
+        original_dumps = pickle.dumps
+        call_count = [0]
+
+        def failing_dumps(obj, protocol=None):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                raise RuntimeError("simulated serialization failure")
+            return original_dumps(obj, protocol=protocol)
+
+        monkeypatch.setattr(pickle, "dumps", failing_dumps)
+
+        with pytest.raises(RuntimeError, match="simulated serialization failure"):
+            script_mod.reexport_layered_definition_models(model_path)
+
+        # The .part file must have been removed.
+        tmp_part = model_path.with_name(model_path.name + ".part")
+        assert not tmp_part.exists(), ".part file must be cleaned up on exception"
+
+    def test_original_file_not_corrupted_on_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        The original model file must not be replaced when an exception occurs.
+        """
+        payload_zip = _make_layered_zip({"term": "original"}, {"def": "original"})
+        model_path = tmp_path / "definition_model_layered.pickle.gzip"
+        model_path.write_bytes(payload_zip)
+        original_content = model_path.read_bytes()
+
+        fake_payload = {
+            "term.pickle": {"term": "original"},
+            "definition.pickle": {"def": "original"},
+        }
+        monkeypatch.setattr(
+            script_mod, "load_layered_definition_models", lambda _p: fake_payload
+        )
+
+        original_dumps = pickle.dumps
+        call_count = [0]
+
+        def failing_dumps(obj, protocol=None):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                raise RuntimeError("write failed")
+            return original_dumps(obj, protocol=protocol)
+
+        monkeypatch.setattr(pickle, "dumps", failing_dumps)
+
+        with pytest.raises(RuntimeError):
+            script_mod.reexport_layered_definition_models(model_path)
+
+        # The original file must be intact.
+        assert model_path.read_bytes() == original_content
+
+    def test_successful_reexport_replaces_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        On success, the model file is replaced and the .part file is gone.
+        """
+        payload_zip = _make_layered_zip({"term": "v1"}, {"def": "v1"})
+        model_path = tmp_path / "definition_model_layered.pickle.gzip"
+        model_path.write_bytes(payload_zip)
+
+        fake_payload = {
+            "term.pickle": {"term": "v2"},
+            "definition.pickle": {"def": "v2"},
+        }
+        monkeypatch.setattr(
+            script_mod, "load_layered_definition_models", lambda _p: fake_payload
+        )
+
+        script_mod.reexport_layered_definition_models(model_path)
+
+        # The .part file must not remain.
+        tmp_part = model_path.with_name(model_path.name + ".part")
+        assert not tmp_part.exists()
+
+        # The model file must now contain the updated payload.
+        assert model_path.exists()
+        with ZipFile(model_path) as zf:
+            reloaded_term = pickle.loads(zf.read("term.pickle"))
+            reloaded_def = pickle.loads(zf.read("definition.pickle"))
+        assert reloaded_term == {"term": "v2"}
+        assert reloaded_def == {"def": "v2"}
+
+    def test_preexisting_part_file_is_removed_before_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        If a stale .part file already exists, it must be removed before writing.
+        """
+        payload_zip = _make_layered_zip({"t": 1}, {"d": 1})
+        model_path = tmp_path / "definition_model_layered.pickle.gzip"
+        model_path.write_bytes(payload_zip)
+
+        # Create a stale .part file.
+        tmp_part = model_path.with_name(model_path.name + ".part")
+        tmp_part.write_bytes(b"stale content")
+
+        fake_payload = {
+            "term.pickle": {"t": 2},
+            "definition.pickle": {"d": 2},
+        }
+        monkeypatch.setattr(
+            script_mod, "load_layered_definition_models", lambda _p: fake_payload
+        )
+
+        # Should succeed even with the stale .part file.
+        script_mod.reexport_layered_definition_models(model_path)
+
+        assert not tmp_part.exists()
+        assert model_path.exists()

--- a/scripts/tests/test_train_contract_type_model.py
+++ b/scripts/tests/test_train_contract_type_model.py
@@ -1,0 +1,346 @@
+"""Tests for scripts/train_contract_type_model.py.
+
+Covers changes introduced in the PR:
+  - main(): stratification fallback (try/except ValueError on train_test_split)
+  - main(): wrote_artifact is included in the JSON report
+  - main(): returns exit code 1 when wrote=False (artifact already exists)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the scripts package importable.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_argv(tmp_path: Path, *, force: bool = False, extra: list | None = None) -> list[str]:
+    output_json = tmp_path / "report.json"
+    argv = [
+        "--target-tag", "pipeline/test/0.1",
+        "--output-json", str(output_json),
+    ]
+    if force:
+        argv.append("--force")
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+def _patch_runtime_model(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    corpus_path: Path,
+    texts: list[str],
+    labels: list[str],
+    pipeline: object,
+    destination: Path,
+    wrote: bool,
+) -> None:
+    """Patch all the lexnlp.extract.en.contracts.runtime_model imports used in the script."""
+    import train_contract_type_model as script_mod
+
+    monkeypatch.setattr(script_mod, "ensure_tag_downloaded", lambda tag: corpus_path)
+    monkeypatch.setattr(
+        script_mod,
+        "collect_contract_type_samples",
+        lambda _archive, *, max_docs_per_label, head_character_n: (texts, labels, {}),
+    )
+    monkeypatch.setattr(
+        script_mod,
+        "train_contract_type_pipeline",
+        lambda _texts, _labels, *, random_state: pipeline,
+    )
+    monkeypatch.setattr(
+        script_mod,
+        "write_pipeline_to_catalog",
+        lambda *, pipeline, target_tag, force: (destination, wrote),
+    )
+
+
+# ---------------------------------------------------------------------------
+# wrote_artifact in report
+# ---------------------------------------------------------------------------
+
+
+class TestWroteArtifactInReport:
+    """The JSON report must include a 'wrote_artifact' key."""
+
+    def test_report_includes_wrote_artifact_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "pipeline_contract_type_classifier.cloudpickle"
+        destination.write_bytes(b"model")
+
+        texts = [f"document {i}" for i in range(10)]
+        labels = (["A"] * 5) + (["B"] * 5)
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=True,
+        )
+
+        output_json = tmp_path / "report.json"
+        rc = script_mod.main(
+            [
+                "--target-tag", "pipeline/test/0.1",
+                "--output-json", str(output_json),
+                "--force",
+            ]
+        )
+
+        assert rc == 0
+        report = json.loads(output_json.read_text(encoding="utf-8"))
+        assert "wrote_artifact" in report
+        assert report["wrote_artifact"] is True
+
+    def test_report_includes_wrote_artifact_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "pipeline_contract_type_classifier.cloudpickle"
+        destination.write_bytes(b"model")
+
+        texts = [f"document {i}" for i in range(10)]
+        labels = (["A"] * 5) + (["B"] * 5)
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=False,  # artifact already exists
+        )
+
+        output_json = tmp_path / "report.json"
+        rc = script_mod.main(
+            [
+                "--target-tag", "pipeline/test/0.1",
+                "--output-json", str(output_json),
+            ]
+        )
+
+        # Returns 1 when wrote=False.
+        assert rc == 1
+        report = json.loads(output_json.read_text(encoding="utf-8"))
+        assert "wrote_artifact" in report
+        assert report["wrote_artifact"] is False
+
+
+# ---------------------------------------------------------------------------
+# Exit code 1 when artifact already exists (wrote=False)
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodeWhenNotWrote:
+    def test_exit_code_1_when_wrote_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "model.pkl"
+        destination.write_bytes(b"existing")
+
+        texts = [f"doc {i}" for i in range(6)]
+        labels = (["X"] * 3) + (["Y"] * 3)
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=False,
+        )
+
+        output_json = tmp_path / "report.json"
+        rc = script_mod.main(
+            ["--target-tag", "pipeline/test/0.1", "--output-json", str(output_json)]
+        )
+        assert rc == 1
+
+    def test_exit_code_0_when_wrote_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "model.pkl"
+        destination.write_bytes(b"new")
+
+        texts = [f"doc {i}" for i in range(6)]
+        labels = (["X"] * 3) + (["Y"] * 3)
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=True,
+        )
+
+        output_json = tmp_path / "report.json"
+        rc = script_mod.main(
+            ["--target-tag", "pipeline/test/0.1", "--output-json", str(output_json), "--force"]
+        )
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Stratification fallback
+# ---------------------------------------------------------------------------
+
+
+class TestStratificationFallback:
+    """
+    When train_test_split raises ValueError due to stratification constraints,
+    the script must retry without stratification rather than propagating the error.
+    """
+
+    def test_stratification_fallback_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Simulate a corpus where one label has only one sample so stratification
+        fails; the retry without stratification must succeed.
+        """
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "model.pkl"
+        destination.write_bytes(b"model")
+
+        # Both labels have >= 2 samples so can_stratify is True.
+        # The mock will then simulate a stratification failure.
+        texts = [f"doc {label} {i}" for i in range(3) for label in ["A", "B"]]
+        labels = ["A", "B", "A", "B", "A", "B"]
+        # Use a pipeline whose predict() adapts to input size.
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=True,
+        )
+
+        # Patch train_test_split to raise ValueError on first call (stratified),
+        # then succeed on second call (no stratification).
+        from sklearn.model_selection import train_test_split as real_split
+
+        call_count = [0]
+
+        def mock_split(X, y, *, test_size, random_state, stratify, shuffle):
+            call_count[0] += 1
+            if call_count[0] == 1 and stratify is not None:
+                raise ValueError("stratify error: not enough members")
+            return real_split(
+                X, y, test_size=test_size, random_state=random_state, shuffle=shuffle
+            )
+
+        monkeypatch.setattr(script_mod, "train_test_split", mock_split)
+
+        output_json = tmp_path / "report.json"
+        rc = script_mod.main(
+            ["--target-tag", "pipeline/test/0.1", "--output-json", str(output_json), "--force"]
+        )
+
+        assert rc == 0
+        # Ensure train_test_split was called twice (once with stratify, once without).
+        assert call_count[0] == 2
+
+    def test_stratification_used_when_possible(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        When min samples per label >= 2, stratification must be attempted first.
+        """
+        import train_contract_type_model as script_mod
+
+        corpus = tmp_path / "corpus.tar.xz"
+        corpus.write_bytes(b"")
+        destination = tmp_path / "model.pkl"
+        destination.write_bytes(b"model")
+
+        texts = [f"doc {i}" for i in range(8)]
+        labels = (["A"] * 4) + (["B"] * 4)
+        pipeline = MagicMock()
+        pipeline.predict.side_effect = lambda X: ["A"] * len(X)
+
+        _patch_runtime_model(
+            monkeypatch,
+            corpus_path=corpus,
+            texts=texts,
+            labels=labels,
+            pipeline=pipeline,
+            destination=destination,
+            wrote=True,
+        )
+
+        from sklearn.model_selection import train_test_split as real_split
+
+        stratify_calls = []
+
+        def mock_split(X, y, *, test_size, random_state, stratify, shuffle):
+            stratify_calls.append(stratify)
+            return real_split(
+                X, y, test_size=test_size, random_state=random_state,
+                stratify=stratify, shuffle=shuffle
+            )
+
+        monkeypatch.setattr(script_mod, "train_test_split", mock_split)
+
+        output_json = tmp_path / "report.json"
+        script_mod.main(
+            ["--target-tag", "pipeline/test/0.1", "--output-json", str(output_json), "--force"]
+        )
+
+        # The first call must use stratify (not None).
+        assert stratify_calls[0] is not None

--- a/scripts/train_contract_model.py
+++ b/scripts/train_contract_model.py
@@ -191,14 +191,17 @@ def ensure_tag_downloaded(tag: str) -> Path:
 
 
 def patch_legacy_estimator_attributes(pipeline: Pipeline) -> None:
-    estimator = pipeline._final_estimator
+    # Use public APIs to access the final estimator and intermediate transforms.
+    estimator = pipeline.steps[-1][1]
     if hasattr(estimator, "sigma_"):
         if not hasattr(estimator, "var_"):
             estimator.var_ = estimator.sigma_
         if not hasattr(estimator, "variance_"):
             estimator.variance_ = estimator.var_
 
-    for _, _, transform in pipeline._iter(with_final=False):
+    for _, transform in pipeline.steps[:-1]:
+        if transform is None or transform == "passthrough":
+            continue
         transform.clip = hasattr(transform, "clip") and transform.clip
 
 
@@ -277,7 +280,13 @@ def make_estimator(name: str, *, random_state: int, max_workers: int):
     raise ValueError(f"Unsupported estimator: {name}")
 
 
-def build_candidate_pipeline(feature_steps: Sequence[Tuple[str, object]], estimator_name: str, *, random_state: int, max_workers: int) -> Pipeline:
+def build_candidate_pipeline(
+    feature_steps: Sequence[Tuple[str, object]],
+    estimator_name: str,
+    *,
+    random_state: int,
+    max_workers: int,
+) -> Pipeline:
     steps = [(name, copy.deepcopy(step)) for name, step in feature_steps]
     steps.append((estimator_name, make_estimator(estimator_name, random_state=random_state, max_workers=max_workers)))
     return Pipeline(steps=steps)
@@ -368,7 +377,7 @@ def run_quality_gate(
     if baseline_metrics_json.exists():
         cmd.extend(["--baseline-metrics-json", str(baseline_metrics_json)])
 
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
 def main(argv: Sequence[str]) -> int:
@@ -490,8 +499,24 @@ def main(argv: Sequence[str]) -> int:
                 max_f1_regression=args.max_f1_regression,
             )
             report["quality_gate"]["status"] = "passed"
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as exc:
             report["quality_gate"]["status"] = "failed"
+            report["quality_gate"]["returncode"] = str(exc.returncode)
+
+            def _decode(stream: object) -> str:
+                if stream is None:
+                    return ""
+                if isinstance(stream, bytes):
+                    return stream.decode("utf-8", errors="replace")
+                return str(stream)
+
+            stdout_text = _decode(getattr(exc, "stdout", None) or getattr(exc, "output", None))
+            stderr_text = _decode(getattr(exc, "stderr", None))
+            if stdout_text:
+                report["quality_gate"]["stdout"] = stdout_text
+            if stderr_text:
+                report["quality_gate"]["stderr"] = stderr_text
+                print(stderr_text, file=sys.stderr)
             if not args.keep_candidate_on_failure and candidate_model_path.exists():
                 candidate_model_path.unlink()
                 report["quality_gate"]["candidate_removed"] = True

--- a/scripts/train_contract_type_model.py
+++ b/scripts/train_contract_type_model.py
@@ -99,14 +99,28 @@ def main(argv: Sequence[str]) -> int:
     label_counts = Counter(labels)
     can_stratify = min(label_counts.values()) >= 2
 
-    x_train, x_val, y_train, y_val = train_test_split(
-        texts,
-        labels,
-        test_size=args.validation_size,
-        random_state=args.random_state,
-        stratify=labels if can_stratify else None,
-        shuffle=True,
-    )
+    try:
+        x_train, x_val, y_train, y_val = train_test_split(
+            texts,
+            labels,
+            test_size=args.validation_size,
+            random_state=args.random_state,
+            stratify=labels if can_stratify else None,
+            shuffle=True,
+        )
+    except ValueError:
+        # train_test_split raises when the requested split cannot satisfy the
+        # stratification constraint (e.g., fewer samples in a class than the
+        # number of classes required per split). Retry without stratification.
+        can_stratify = False
+        x_train, x_val, y_train, y_val = train_test_split(
+            texts,
+            labels,
+            test_size=args.validation_size,
+            random_state=args.random_state,
+            stratify=None,
+            shuffle=True,
+        )
 
     validation_pipeline = train_contract_type_pipeline(
         x_train,
@@ -121,7 +135,7 @@ def main(argv: Sequence[str]) -> int:
         labels,
         random_state=args.random_state,
     )
-    destination = write_pipeline_to_catalog(
+    destination, wrote = write_pipeline_to_catalog(
         pipeline=final_pipeline,
         target_tag=args.target_tag,
         force=args.force,
@@ -130,6 +144,7 @@ def main(argv: Sequence[str]) -> int:
     report = {
         "target_tag": args.target_tag,
         "target_model_path": str(destination),
+        "wrote_artifact": wrote,
         "corpus_tag": args.corpus_tag,
         "corpus_path": str(corpus_archive),
         "dataset": {
@@ -148,6 +163,14 @@ def main(argv: Sequence[str]) -> int:
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
     print(json.dumps(report, indent=2, sort_keys=True))
+
+    if not wrote:
+        print(
+            f"Skipped writing artifact for target_tag={args.target_tag!r}; "
+            "catalog entry already exists (use --force to overwrite).",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,6 @@ requires-dist = [
     { name = "dateparser", specifier = "==1.1.3" },
     { name = "elasticsearch", specifier = ">=8.5.0,<9" },
     { name = "gensim", specifier = ">=4.3.2,<5" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'", specifier = ">=5.0.0" },
     { name = "joblib", specifier = ">=1.2.0,<2" },
     { name = "lxml", specifier = ">=4.9.1,<6" },
     { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61.0" },


### PR DESCRIPTION
Address actionable suggestions from the CodeRabbit review on PR #9.

Highlights:
- pyproject.toml: raise setuptools minimum to 77.0.0 for SPDX license
  support and drop the unreachable importlib-metadata backport.
- lexnlp/extract/es/regulations.py: drop dead error_bad_lines fallback
  now that pandas>=2.2 is required; always use on_bad_lines='skip'.
- lexnlp/ml/catalog: guard _TAG_DICT_CACHE with a threading.Lock using
  double-checked locking.
- lexnlp/ml/catalog/download.py: drop redundant raise_for_status in
  _get_asset (already handled by get_tag).
- lexnlp/ml/predictor.py: rename unused name to _name in pipeline loop.
- lexnlp/nlp/en/segments/titles.py: pass dtype=float when converting
  features to numpy for consistency with other segmenters.
- lexnlp/utils/amount_delimiting.py: also override grouping when de_DE
  locale is misconfigured so check_block_grouping validates correctly.
- lexnlp/extract/en/contracts/runtime_model.py: drop stray `pass`, log
  the force=False skip path, and return (Path, wrote) from
  write_pipeline_to_catalog.
- scripts/bootstrap_assets.py: bind lambda captures via default args,
  validate download URL schemes, and harden extract_zip against
  zip-slip.
- scripts/asset_drift_check.py: stop double-lowercasing actual sha and
  include the exception class name in failures.
- scripts/contract_type_quality_gate.py: fix deprecated
  --max-accuracy-top3-regression alias so top-N regression default is
  never None, and enforce strict=True on zip().
- scripts/model_quality_gate.py: align default is-contract tag with
  bootstrap (0.2).
- scripts/reexport_bundled_sklearn_models.py: narrow Exception catch to
  the expected pickle/joblib errors and clean up the .part temp file on
  failure.
- scripts/reexport_contract_model.py: capture subprocess stdout/stderr
  in run_quality_gate and make the warning-probe subprocess resilient
  to import/load errors.
- scripts/train_contract_model.py: split the long build_candidate_pipeline
  signature, replace private sklearn APIs with public attributes, and
  record stdout/stderr on quality-gate failure.
- scripts/train_contract_type_model.py: fall back to unstratified split
  when stratification is infeasible, and surface when
  write_pipeline_to_catalog skipped writing an artifact.
- .github/workflows: install dev/test extras in publish workflows and
  drop redundant fallback tag resolution.
- Tests & docs: drop redundant monkeypatch restoration in
  test_catalog_path, update the runtime_model mock for the new
  write_pipeline_to_catalog API, and replace the hard-coded
  /Users/jackeames/Downloads/LexNLP developer path in README.rst,
  README.md, AGENTS.md, MIGRATION_RUNBOOK.md, and notes.md.

https://claude.ai/code/session_01B99wdGuWFcowSU3cPaLReS

## Summary by Sourcery

Apply review-driven hardening and cleanup across model training/bootstrap scripts, runtime contract-type model utilities, catalog caching, and CI publish workflows.

Bug Fixes:
- Make contract-type training resilient to infeasible stratified splits by falling back to unstratified splitting.
- Surface when runtime contract-type artifacts are skipped or overwritten by returning a wrote flag from write_pipeline_to_catalog and propagating it to callers.
- Include subprocess stdout/stderr and return codes in quality gate failure reports for contract and contract-type models.
- Prevent unsafe ZIP extraction and disallow non-HTTP(S) URLs in asset bootstrapping downloads.
- Fix contract-type quality gate CLI defaults and argument aliasing so top-N regression thresholds are always defined.
- Ensure de_DE amount delimiter inference also normalizes grouping configuration so validation passes.
- Avoid double-lowercasing SHA256 digests and improve error messages in asset drift checks.
- Harden model re-export scripts by narrowing deserialization exception handling, cleaning up temp files on failure, and making legacy warning probes robust to load/import errors.
- Remove redundant HTTP error handling in catalog asset downloads to rely on centralized logic.
- Update English title segmentation to pass float arrays into sklearn and avoid dtype-related issues.

Enhancements:
- Guard the ML catalog tag dictionary cache with a lock using double-checked locking to make access thread-safe.
- Log and skip existing runtime contract-type artifacts when force is False, and improve logging on earlier load failures.
- Modernize pandas CSV loading for Spanish regulations by always using on_bad_lines='skip' now that older pandas versions are unsupported.
- Refine sklearn pipeline patching to use public attributes and skip passthrough/None transforms.
- Capture and propagate quality gate subprocess output in training scripts for easier debugging.
- Make bootstrap task lambdas stable by binding loop variables via default arguments.
- Simplify catalog path tests by removing redundant HOME restoration.
- General documentation cleanup to remove hard-coded local filesystem paths from README and notes files.

Build:
- Raise the minimum setuptools version to 77.0.0 in pyproject and drop the importlib-metadata backport dependency.

CI:
- Update publish workflows to install dev/test extras and to require an explicit model tag for contract-type runtime model publishing.

Documentation:
- Replace hard-coded local developer paths with generic /path/to/LexNLP in README, AGENTS, MIGRATION_RUNBOOK, and notes documentation.

Tests:
- Adjust runtime_model tests for the updated write_pipeline_to_catalog return signature.