### PR TITLE
Fix bugs and improve test coverage aAPI exports, enhanced validation, and type annotation updatesoss multiple modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv .venv --python 3.14
-          uv sync --python .venv/bin/python --group dev
+          uv sync --frozen --python .venv/bin/python --group dev
 
       - name: Bootstrap required assets
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,11 @@
 #
 # Install locally with::
 #
-#     uv run --group lint pre-commit install
+#     uvx pre-commit install
+#
+# ``uvx`` runs ``pre-commit`` outside the project's dependency groups so
+# fresh contributors do not need ``pre-commit`` installed globally and the
+# ``lint`` group does not need to ship it.
 #
 # Hooks intentionally mirror what CI runs so a local ``git commit``
 # catches the same issues. Every tool is pinned to a recent release to

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -20,7 +20,7 @@ LexNLP is a legal-domain NLP toolkit. The public surface is:
 - **`lexnlp.ml`** — asset catalog, gensim helpers, sklearn transformers,
   and now `model_io` (skops + legacy pickle fallback).
 - **`lexnlp.utils`** — locale-aware amount delimiting, decorators,
-  unicode lookup, CSV/DataFrame helpers.
+  Unicode lookup, CSV/DataFrame helpers.
 - **`scripts/`** — training / evaluation / quality-gate / bootstrap /
   drift-check utilities, plus release publishing workflows.
 
@@ -37,7 +37,7 @@ freely pick up security / feature releases.
 | --- | --- | --- | --- | --- |
 | Python | `3.10.*` | **3.13.12** | `>=3.13,<3.15` | PEP 604 `X \| Y`, PEP 585 builtin generics, PEP 695 `type` alias, PEP 698 `@override`, PEP 701 multiline f-strings, PEP 709 inlined comprehensions, PEP 667 frame semantics, free-threaded build (`--disable-gil`), `tomllib` stdlib, `asyncio.TaskGroup`, `Self` type, JIT (experimental), better error messages and tracebacks, faster interpreter startup, improved `typing.override` |
 | scikit-learn | `0.24.0` | **1.8.0** | `>=1.5` | `set_config(transform_output="pandas")`, full metadata routing (SLEP006), `TunedThresholdClassifierCV`, `HistGradientBoosting` native categorical handling, `feature_names_out` standardised across all transformers, `__sklearn_tags__` API (1.6+), `ColumnTransformer.set_output`, `FrozenEstimator`, Array API support (GPU arrays), `roc_auc_score(multi_class="ovr", average="macro")` defaults, `PartialDependenceDisplay` categorical support, constrained linear models |
-| numpy | `1.23.4` | **2.4.4** | `>=2.3,<3` | **NumPy 2.0 (Jun 2024)**: NEP 50 default scalar promotion (cleaner int/float rules), removal of deprecated aliases (`np.int`, `np.float`, `np.NaN`, `np.product`, `np.trapz`, `np.in1d`, `np.round_`, `np.sometrue`, …), new `numpy.exceptions` namespace, strict type promotion, stable `numpy.typing.NDArray`, revamped C/Python ABI, `numpy.strings` unicode vectorised ops. **NumPy 2.1 (Aug 2024)**: default `np.dtype` repr, `matvec`/`vecmat`/`vecdot` generalised ufuncs, improved `__array_namespace__` for Array API, `numpy.dtypes.StringDType`, windows Py3.13 wheels. **NumPy 2.2 (Dec 2024)**: `numpy.lib.array_utils.normalize_axis_index`, nanquantile fast path, faster f-contiguous reductions, `out=` kwarg on `np.unique*`, `numpy.strings.slice()`. **NumPy 2.3 (Jun 2025)**: `np.random.Generator.spawn`, SIMD-accelerated string functions, free-threaded CPython support, extended Array API compliance. **NumPy 2.4 (Oct 2025)**: SVE/SME kernels on ARM, `out=` support in more ufuncs, faster `setdiff1d`, BLAS vendored wheels. Features the codebase specifically benefits from: stable `numpy.typing`, Array API passthrough for sklearn 1.8 GPU path, strict scalar promotion (eliminates silent float→int coercion), new `exceptions` namespace for precise error handling. |
+| numpy | `1.23.4` | **2.4.4** | `>=2.3,<3` | **NumPy 2.0 (Jun 2024)**: NEP 50 default scalar promotion (cleaner int/float rules), removal of deprecated aliases (`np.int`, `np.float`, `np.NaN`, `np.product`, `np.trapz`, `np.in1d`, `np.round_`, `np.sometrue`, …), new `numpy.exceptions` namespace, strict type promotion, stable `numpy.typing.NDArray`, revamped C/Python ABI, `numpy.strings` Unicode vectorised ops. **NumPy 2.1 (Aug 2024)**: default `np.dtype` repr, `matvec`/`vecmat`/`vecdot` generalised ufuncs, improved `__array_namespace__` for Array API, `numpy.dtypes.StringDType`, Windows Py3.13 wheels. **NumPy 2.2 (Dec 2024)**: `numpy.lib.array_utils.normalize_axis_index`, nanquantile fast path, faster f-contiguous reductions, `out=` kwarg on `np.unique*`, `numpy.strings.slice()`. **NumPy 2.3 (Jun 2025)**: `np.random.Generator.spawn`, SIMD-accelerated string functions, free-threaded CPython support, extended Array API compliance. **NumPy 2.4 (Oct 2025)**: SVE/SME kernels on ARM, `out=` support in more ufuncs, faster `setdiff1d`, BLAS vendored wheels. Features the codebase specifically benefits from: stable `numpy.typing`, Array API passthrough for sklearn 1.8 GPU path, strict scalar promotion (eliminates silent float→int coercion), new `exceptions` namespace for precise error handling. |
 | pandas | `1.5.1` | **2.3.3** | `>=2.2.0,<3` | Copy-on-Write default, PyArrow-backed dtypes, `read_csv(dtype_backend="pyarrow")`, nullable dtypes stable, `DataFrame.map`, `Series.case_when`, deprecated `inplace=True` path removed, `.from_records` on Arrow types, `.agg` preserves dtype |
 | regex | `2022.3.2` | **2025.11.3** | `>=2024.0` | Possessive quantifiers, improved unicode property matching, fuzzy matching (`{e<=n}`), grapheme-cluster `\X`, named-group recursion, multi-threaded compile cache |
 | nltk | `3.7` | **3.9.4** | `>=3.9` | `punkt_tab` replaces `punkt` (faster, deterministic), security fixes (CVE-2024-39705 pickle), updated averaged-perceptron tagger, POS tagging on OOV tokens, stopwords refresh |
@@ -223,7 +223,7 @@ These remain open and are **not** blockers for shipping the PT module:
     `claude/numpy-upgrade-features-qVF34` — new
     `lexnlp.ml.model_card` module with `ModelCardMetadata`,
     `write_model_card` and `dump_model_with_card` so every release
-    artifact ships a sibling ``.md`` card describing description,
+    artifact ships a sibling ``.md`` card containing the description,
     license, authors, tags, metrics and hyper-parameters.*
 11. **Trusted skops allow-list**: ✅ *Done on
     `claude/numpy-upgrade-features-qVF34` —
@@ -274,7 +274,7 @@ These remain open and are **not** blockers for shipping the PT module:
     is shipped under the ``[hub]`` optional extra.*
 20. **`rapidfuzz`-based matcher** for fuzzy legal-term lookups
     (currently done with regex alternation). Faster and
-    unicode-aware.
+    Unicode-aware.
 21. **Async / parallel asset download**: `httpx.AsyncClient` with
     `tqdm.asyncio.gather` in
     `scripts/bootstrap_assets.py::download_many` — right now each
@@ -374,7 +374,7 @@ architecture and extended for Brazilian legal prose. The branch
      ``Decreto-Lei nº 4.657/1942``, ``Lei Complementar nº 101/2000``) —
      tolerant of the planalto-mirror glitch where ``nº`` renders as
      ``n o`` across a line break.
-  3. Article / paragraph / incision / alinea references
+  3. Article / paragraph / incision / alínea references
      (``art. 5º, inciso XXXIII``, ``§ 2º do art. 12``).
   4. Constitutional references (``Constituição Federal``,
      ``CRFB/88``, ``CF/88``).
@@ -545,7 +545,7 @@ unittest module that reproduces the intended contract:
   `lexnlp/ml/tests/test_model_card.py` (7 tests).
 
 * **Tier B.11 — `DEFAULT_TRUSTED_ALLOWLIST`** in
-  `lexnlp.ml.model_io`. An explicit frozenset of sklearn / numpy type
+  `lexnlp.ml.model_io`. An explicit frozenset of sklearn / NumPy type
   names is intersected against the artifact's declared untrusted
   types before skops is asked to load — so ``trusted=True`` is no
   longer "accept anything the artifact declares", it is "accept only

--- a/TY_CHECK_TODO.md
+++ b/TY_CHECK_TODO.md
@@ -24,7 +24,7 @@ or ship unsafe behaviour first, bulk typing chores last.
       ([de_date_parser.py:46](lexnlp/extract/de/de_date_parser.py)). The
       PT override is already correct; align DE with the base signature so
       `DateParser` subclasses are interchangeable.
-- [ ] **`error[index-out-of-bounds]` (1)** — review the single case ty flags
+- [ ] **`error[index-out-of-bounds]` (1)** — review the single case that ty flags
       and add a bounds guard.
 - [ ] **`error[call-non-callable]` (1)** — investigate; almost always a
       bug (calling a property / None / class-stored dict).

--- a/lexnlp/extract/batch/async_extract.py
+++ b/lexnlp/extract/batch/async_extract.py
@@ -291,6 +291,7 @@ def flatten[T](results: Iterable[BatchExtractionResult[T]]) -> list[T]:
 
 __all__ = [
     "BatchExtractionResult",
+    "adaptive_max_workers",
     "extract_batch",
     "extract_batch_async",
     "flatten",

--- a/lexnlp/extract/batch/tests/test_parallel_rng.py
+++ b/lexnlp/extract/batch/tests/test_parallel_rng.py
@@ -5,6 +5,7 @@ __version__ = "2.3.0"
 __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
+import importlib
 from unittest import TestCase
 
 import numpy as np
@@ -13,6 +14,19 @@ from lexnlp.extract.batch.parallel_rng import spawn_child_generators
 
 
 class TestSpawnChildGenerators(TestCase):
+    def test_public_reexport_is_callable(self):
+        """``spawn_child_generators`` is part of the package's public API
+        surface and must remain importable from ``lexnlp.extract.batch``."""
+        module = importlib.import_module("lexnlp.extract.batch")
+        reexport = getattr(module, "spawn_child_generators")
+        self.assertTrue(callable(reexport))
+        # Sanity-check that the re-exported symbol is the same object as
+        # the one importable from the submodule.
+        self.assertIs(reexport, spawn_child_generators)
+        # Smoke-call the public path so we exercise it end-to-end.
+        children = reexport(seed=5, n=1)
+        self.assertEqual(len(children), 1)
+
     def test_returns_n_generators(self):
         children = spawn_child_generators(seed=42, n=4)
         self.assertEqual(len(children), 4)

--- a/lexnlp/extract/batch/tests/test_parallel_rng.py
+++ b/lexnlp/extract/batch/tests/test_parallel_rng.py
@@ -73,3 +73,72 @@ class TestSpawnChildGenerators(TestCase):
         first = spawn_child_generators(seed=7, n=1)[0].integers(0, 1000, size=10)
         second = spawn_child_generators(seed=7, n=1)[0].integers(0, 1000, size=10)
         self.assertTrue(np.array_equal(first, second))
+
+
+class TestAdaptiveMaxWorkers(TestCase):
+    """Tests for ``adaptive_max_workers``, which was added to ``__all__`` in this PR."""
+
+    def test_in_async_extract_all(self):
+        """adaptive_max_workers must be listed in async_extract.__all__."""
+        from lexnlp.extract.batch.async_extract import __all__ as async_all
+
+        self.assertIn("adaptive_max_workers", async_all)
+
+    def test_importable_from_package(self):
+        """adaptive_max_workers must be re-exported from lexnlp.extract.batch."""
+        module = importlib.import_module("lexnlp.extract.batch")
+        self.assertTrue(hasattr(module, "adaptive_max_workers"))
+        self.assertTrue(callable(module.adaptive_max_workers))
+
+    def test_package_all_contains_adaptive_max_workers(self):
+        """__all__ in lexnlp.extract.batch must include adaptive_max_workers."""
+        module = importlib.import_module("lexnlp.extract.batch")
+        all_names = getattr(module, "__all__", [])
+        self.assertIn("adaptive_max_workers", all_names)
+
+    def test_returns_positive_integer(self):
+        """adaptive_max_workers must always return a positive integer."""
+        from lexnlp.extract.batch.async_extract import adaptive_max_workers
+
+        result = adaptive_max_workers()
+        self.assertIsInstance(result, int)
+        self.assertGreater(result, 0)
+
+    def test_returns_at_least_one(self):
+        """Even on a single-core machine the result must be >= 1."""
+        from unittest.mock import patch
+
+        from lexnlp.extract.batch.async_extract import adaptive_max_workers
+
+        class FakeMemory:
+            available = 0  # 0 GiB available
+
+        with patch("psutil.cpu_count", return_value=1):
+            with patch("psutil.virtual_memory", return_value=FakeMemory()):
+                result = adaptive_max_workers()
+        self.assertGreaterEqual(result, 1)
+
+    def test_capped_by_physical_cores(self):
+        """Result must not exceed the number of physical CPU cores."""
+        from unittest.mock import patch
+
+        from lexnlp.extract.batch.async_extract import adaptive_max_workers
+
+        class FakeMemory:
+            available = 1024 ** 3 * 1000  # 1000 GiB — unlimited RAM
+
+        with patch("psutil.cpu_count", return_value=4):
+            with patch("psutil.virtual_memory", return_value=FakeMemory()):
+                result = adaptive_max_workers()
+        self.assertLessEqual(result, 4)
+
+    def test_fallback_when_psutil_missing(self):
+        """When psutil is not importable the function must return 8."""
+        import sys
+        from unittest.mock import patch
+
+        from lexnlp.extract.batch.async_extract import adaptive_max_workers
+
+        with patch.dict(sys.modules, {"psutil": None}):
+            result = adaptive_max_workers()
+        self.assertEqual(result, 8)

--- a/lexnlp/extract/common/annotations/citation_annotation.py
+++ b/lexnlp/extract/common/annotations/citation_annotation.py
@@ -114,9 +114,9 @@ class CitationAnnotation(TextAnnotation):
             df.tags["Extracted Entity Reporter"] = str(self.reporter)
         if self.reporter_full_name:
             df.tags["Extracted Entity Reporter Full Name"] = str(self.reporter_full_name)
-        if self.reporter:
+        if self.court:
             df.tags["Extracted Entity Court"] = str(self.court)
-        if self.reporter:
+        if self.source:
             df.tags["Extracted Entity Source"] = str(self.source)
 
         return df

--- a/lexnlp/extract/common/annotations/ssn_annotation.py
+++ b/lexnlp/extract/common/annotations/ssn_annotation.py
@@ -31,7 +31,11 @@ class SsnAnnotation(TextAnnotation):
         self.number = number
 
     def get_cite_value_parts(self) -> list[str]:
-        return [self.number]
+        # ``self.number`` is typed as ``str | None`` to allow tests / partial
+        # captures that haven't resolved the value yet; the cite parts list
+        # is contractually ``list[str]``, so coerce a missing number to an
+        # empty string rather than smuggling ``None`` past the type system.
+        return [self.number or ""]
 
     def get_dictionary_values(self) -> dict:
         df = {"tags": {"Extracted Entity SSN": self.number or "", "Extracted Entity Text": self.text}}

--- a/lexnlp/extract/common/annotations/tests/test_citation_annotation_bugfix.py
+++ b/lexnlp/extract/common/annotations/tests/test_citation_annotation_bugfix.py
@@ -1,0 +1,187 @@
+"""Regression tests for CitationAnnotation.get_dictionary_values court/source fix.
+
+Prior to this PR the conditional checks for ``Extracted Entity Court`` and
+``Extracted Entity Source`` incorrectly tested ``self.reporter`` instead of
+``self.court`` and ``self.source`` respectively.  This file pins the correct
+behaviour so future refactors cannot silently re-introduce the regression.
+
+Bug (before fix):
+    if self.reporter:   # WRONG — should be self.court
+        df.tags["Extracted Entity Court"] = str(self.court)
+    if self.reporter:   # WRONG — should be self.source
+        df.tags["Extracted Entity Source"] = str(self.source)
+
+Fix (after PR):
+    if self.court:
+        df.tags["Extracted Entity Court"] = str(self.court)
+    if self.source:
+        df.tags["Extracted Entity Source"] = str(self.source)
+"""
+
+from __future__ import annotations
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from lexnlp.extract.common.annotations.citation_annotation import CitationAnnotation
+
+
+class TestCitationAnnotationCourtSourceBugfix:
+    """Regression suite for the court/source conditional fix."""
+
+    # ------------------------------------------------------------------
+    # Core regression: court present, reporter absent
+    # ------------------------------------------------------------------
+
+    def test_court_tag_included_when_court_set_and_reporter_none(self) -> None:
+        """Extracted Entity Court must appear even when reporter is None.
+
+        Before the fix, the guard was ``if self.reporter``, which meant a
+        citation with a court but no reporter would silently drop the court
+        tag from the dictionary.
+        """
+        ann = CitationAnnotation(
+            coords=(0, 20),
+            court="SCOTUS",
+            reporter=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Court" in d.tags, (
+            "Extracted Entity Court should be present when court='SCOTUS' and reporter=None"
+        )
+        assert d.tags["Extracted Entity Court"] == "SCOTUS"
+
+    def test_source_tag_included_when_source_set_and_reporter_none(self) -> None:
+        """Extracted Entity Source must appear even when reporter is None."""
+        ann = CitationAnnotation(
+            coords=(0, 30),
+            source="Roe v. Wade, 410 U.S. 113 (1973)",
+            reporter=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Source" in d.tags, (
+            "Extracted Entity Source should be present when source is set and reporter=None"
+        )
+        assert d.tags["Extracted Entity Source"] == "Roe v. Wade, 410 U.S. 113 (1973)"
+
+    # ------------------------------------------------------------------
+    # Both fields absent → no spurious tags
+    # ------------------------------------------------------------------
+
+    def test_court_tag_absent_when_court_is_none(self) -> None:
+        """When court is None the tag must not appear — even when reporter is set."""
+        ann = CitationAnnotation(
+            coords=(0, 20),
+            reporter="U.S.",
+            court=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Court" not in d.tags
+
+    def test_source_tag_absent_when_source_is_none(self) -> None:
+        """When source is None the tag must not appear — even when reporter is set."""
+        ann = CitationAnnotation(
+            coords=(0, 20),
+            reporter="U.S.",
+            source=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Source" not in d.tags
+
+    # ------------------------------------------------------------------
+    # Both fields present → both tags included
+    # ------------------------------------------------------------------
+
+    def test_both_tags_present_when_both_fields_set(self) -> None:
+        """When court and source are both set, both tags appear."""
+        ann = CitationAnnotation(
+            coords=(0, 50),
+            court="9th Cir.",
+            source="United States v. Foo, 999 F.3d 1 (9th Cir. 2021)",
+            reporter=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Court" in d.tags
+        assert "Extracted Entity Source" in d.tags
+        assert d.tags["Extracted Entity Court"] == "9th Cir."
+        assert d.tags["Extracted Entity Source"] == "United States v. Foo, 999 F.3d 1 (9th Cir. 2021)"
+
+    # ------------------------------------------------------------------
+    # Reporter still controls its own tag
+    # ------------------------------------------------------------------
+
+    def test_reporter_tag_included_when_reporter_set(self) -> None:
+        """Reporter field is independent — its tag should appear when set."""
+        ann = CitationAnnotation(
+            coords=(0, 15),
+            reporter="F.3d",
+            court=None,
+            source=None,
+        )
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Reporter" in d.tags
+        assert d.tags["Extracted Entity Reporter"] == "F.3d"
+        # Neither court nor source should appear
+        assert "Extracted Entity Court" not in d.tags
+        assert "Extracted Entity Source" not in d.tags
+
+    def test_reporter_absent_does_not_suppress_court_and_source(self) -> None:
+        """The fix: all three fields are now independent of each other."""
+        ann = CitationAnnotation(
+            coords=(0, 60),
+            reporter=None,
+            court="D.C. Cir.",
+            source="Smith v. Jones, 1 D.C. 1 (D.C. Cir. 2000)",
+        )
+        d = ann.get_dictionary_values()
+        # reporter tag absent
+        assert "Extracted Entity Reporter" not in d.tags
+        # court and source tags present
+        assert d.tags["Extracted Entity Court"] == "D.C. Cir."
+        assert d.tags["Extracted Entity Source"] == "Smith v. Jones, 1 D.C. 1 (D.C. Cir. 2000)"
+
+    # ------------------------------------------------------------------
+    # Full construction — all fields set — everything appears
+    # ------------------------------------------------------------------
+
+    def test_all_tags_present_when_all_fields_set(self) -> None:
+        ann = CitationAnnotation(
+            coords=(5, 80),
+            text="410 U.S. 113",
+            volume=410,
+            reporter="U.S.",
+            reporter_full_name="United States Reports",
+            page=113,
+            year=1973,
+            court="SCOTUS",
+            source="Roe v. Wade",
+        )
+        d = ann.get_dictionary_values()
+        assert d.tags["Extracted Entity Reporter"] == "U.S."
+        assert d.tags["Extracted Entity Reporter Full Name"] == "United States Reports"
+        assert d.tags["Extracted Entity Court"] == "SCOTUS"
+        assert d.tags["Extracted Entity Source"] == "Roe v. Wade"
+
+    # ------------------------------------------------------------------
+    # Minimal construction — no optional fields → only text tag
+    # ------------------------------------------------------------------
+
+    def test_minimal_construction_produces_only_text_tag(self) -> None:
+        ann = CitationAnnotation(coords=(0, 0), text="bare")
+        d = ann.get_dictionary_values()
+        assert "Extracted Entity Text" in d.tags
+        # Optional tags must be absent
+        for key in (
+            "Extracted Entity Volume",
+            "Extracted Entity Year",
+            "Extracted Entity Page",
+            "Extracted Entity Reporter",
+            "Extracted Entity Court",
+            "Extracted Entity Source",
+        ):
+            assert key not in d.tags, f"Unexpected tag '{key}' in minimal annotation"

--- a/lexnlp/extract/common/annotations/tests/test_ssn_annotation_none_number.py
+++ b/lexnlp/extract/common/annotations/tests/test_ssn_annotation_none_number.py
@@ -1,0 +1,73 @@
+"""Tests for SsnAnnotation.get_cite_value_parts None-safety fix.
+
+Before this PR, ``get_cite_value_parts`` returned ``[self.number]``, which
+could smuggle a ``None`` value into a ``list[str]`` and cause downstream
+``str.join`` / concatenation failures.
+
+After the fix it returns ``[self.number or ""]``, coercing a missing number
+to an empty string.
+"""
+
+from __future__ import annotations
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from lexnlp.extract.common.annotations.ssn_annotation import SsnAnnotation
+
+
+class TestSsnAnnotationGetCiteValueParts:
+    """Pin the None-safe behaviour of get_cite_value_parts."""
+
+    def test_none_number_returns_list_with_empty_string(self) -> None:
+        """When number is None, get_cite_value_parts must return [''] not [None].
+
+        Returning [None] would violate the list[str] contract and cause
+        downstream str.join failures.
+        """
+        ann = SsnAnnotation(coords=(0, 10), number=None)
+        parts = ann.get_cite_value_parts()
+        assert parts == [""], f"Expected [''] for None number, got {parts!r}"
+        # Every element must be str — not None
+        for part in parts:
+            assert isinstance(part, str), f"Non-str element {part!r} in cite value parts"
+
+    def test_populated_number_returned_as_is(self) -> None:
+        """When number has a value it must appear in the result unchanged."""
+        ann = SsnAnnotation(coords=(0, 11), number="123-45-6789")
+        parts = ann.get_cite_value_parts()
+        assert parts == ["123-45-6789"]
+
+    def test_empty_string_number_returned_unchanged(self) -> None:
+        """An explicitly set empty string is already a valid str and passes through."""
+        ann = SsnAnnotation(coords=(0, 5), number="")
+        parts = ann.get_cite_value_parts()
+        assert parts == [""]
+
+    def test_returns_list_of_length_one(self) -> None:
+        """Contract: exactly one element regardless of value."""
+        for number in (None, "", "000-00-0000", "987-65-4321"):
+            ann = SsnAnnotation(coords=(0, 0), number=number)
+            parts = ann.get_cite_value_parts()
+            assert len(parts) == 1, f"Expected 1 element for number={number!r}, got {len(parts)}"
+
+    def test_get_dictionary_values_handles_none_number(self) -> None:
+        """get_dictionary_values also uses 'or ""' — verify the tag is not None."""
+        ann = SsnAnnotation(coords=(0, 10), number=None)
+        d = ann.get_dictionary_values()
+        tags = d["tags"]
+        assert tags["Extracted Entity SSN"] == "", (
+            "SSN tag must be empty string when number is None"
+        )
+
+    def test_get_dictionary_values_populated(self) -> None:
+        ann = SsnAnnotation(coords=(0, 11), text="SSN: 123-45-6789", number="123-45-6789")
+        d = ann.get_dictionary_values()
+        tags = d["tags"]
+        assert tags["Extracted Entity SSN"] == "123-45-6789"
+        assert tags["Extracted Entity Text"] == "SSN: 123-45-6789"

--- a/lexnlp/extract/common/countries.py
+++ b/lexnlp/extract/common/countries.py
@@ -21,7 +21,7 @@ __email__ = "support@contraxsuite.com"
 
 
 from dataclasses import dataclass
-from functools import cache, lru_cache
+from functools import lru_cache
 
 import pycountry
 
@@ -45,7 +45,7 @@ def _country_to_info(country: object) -> CountryInfo:
     )
 
 
-@cache
+@lru_cache(maxsize=4096)
 def lookup_country(text: str) -> CountryInfo | None:
     """Look up a country by name, alpha-2, or alpha-3 code."""
     if not text:
@@ -77,7 +77,7 @@ def lookup_country(text: str) -> CountryInfo | None:
     return _country_to_info(country)
 
 
-@cache
+@lru_cache(maxsize=2048)
 def fuzzy_country(text: str, *, max_results: int = 1) -> tuple[CountryInfo, ...]:
     """Fuzzy-match ``text`` against known country names.
 
@@ -86,14 +86,20 @@ def fuzzy_country(text: str, *, max_results: int = 1) -> tuple[CountryInfo, ...]
 
     Args:
         text: The candidate country string.
-        max_results: Number of candidate matches to return. Defaults to 1
-            to keep callers on the precision side; raise this to surface
-            alternative matches for disambiguation UIs.
+        max_results: Number of candidate matches to return. Must be a
+            positive integer; defaults to 1 to keep callers on the
+            precision side. Raise this to surface alternative matches for
+            disambiguation UIs.
 
     Returns:
         A tuple of :class:`CountryInfo` matches. Empty when ``pycountry``
         reports no candidates.
+
+    Raises:
+        ValueError: If ``max_results`` is not a positive integer.
     """
+    if max_results <= 0:
+        raise ValueError(f"max_results must be a positive integer, got {max_results!r}")
     if not text:
         return ()
     try:

--- a/lexnlp/extract/common/tests/test_countries.py
+++ b/lexnlp/extract/common/tests/test_countries.py
@@ -163,8 +163,9 @@ class TestLookupCountryAdditional:
         """Leading/trailing whitespace around the key is normalised."""
         info_plain = lookup_country("US")
         info_padded = lookup_country("  US  ")
+        assert info_plain is not None
         assert info_padded is not None
-        assert info_padded.alpha_2 == info_plain.alpha_2  # type: ignore[union-attr]
+        assert info_padded.alpha_2 == info_plain.alpha_2
 
     def test_official_name_field_exists(self) -> None:
         """CountryInfo dataclass must expose official_name (str | None)."""

--- a/lexnlp/extract/common/tests/test_countries.py
+++ b/lexnlp/extract/common/tests/test_countries.py
@@ -51,12 +51,23 @@ class TestFuzzyCountry:
         names = [m.name for m in matches]
         # Some variation of "United" exists in multiple names.
         assert any("United" in n for n in names)
+        # Honour the explicit cap so noisy fuzzy backends don't surface
+        # more candidates than the caller asked for.
+        assert len(matches) <= 3
 
     def test_empty_returns_empty_tuple(self) -> None:
         assert fuzzy_country("") == ()
 
     def test_no_match_returns_empty_tuple(self) -> None:
         assert fuzzy_country("Valyria") == ()
+
+    def test_invalid_max_results_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_results must be a positive integer"):
+            fuzzy_country("United", max_results=0)
+        with pytest.raises(ValueError, match="max_results must be a positive integer"):
+            fuzzy_country("United", max_results=-1)
 
 
 class TestCurrencyCodes:

--- a/lexnlp/extract/common/tests/test_countries.py
+++ b/lexnlp/extract/common/tests/test_countries.py
@@ -89,3 +89,94 @@ class TestLanguageCodes:
 
     def test_rejects_unknown(self) -> None:
         assert not is_language_code("zz")
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for PR changes: max_results validation & lru_cache
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyCountryMaxResultsBoundary:
+    """Pin boundary behaviour of the new max_results validation."""
+
+    def test_max_results_one_returns_at_most_one(self) -> None:
+        """Default max_results=1 must cap results to a single entry."""
+        matches = fuzzy_country("Germany")
+        assert len(matches) <= 1
+
+    def test_max_results_two_returns_at_most_two(self) -> None:
+        """max_results=2 must cap results to at most two entries."""
+        matches = fuzzy_country("United", max_results=2)
+        assert len(matches) <= 2
+
+    def test_max_results_one_is_explicit_same_as_default(self) -> None:
+        """Explicitly passing max_results=1 is equivalent to the default."""
+        default = fuzzy_country("France")
+        explicit = fuzzy_country("France", max_results=1)
+        assert default == explicit
+
+    def test_max_results_large_does_not_raise(self) -> None:
+        """A large max_results value is valid even if fewer results exist."""
+        matches = fuzzy_country("France", max_results=1000)
+        assert isinstance(matches, tuple)
+
+    def test_max_results_zero_message_includes_value(self) -> None:
+        """The ValueError message must include the invalid value for debugging."""
+        import pytest
+
+        with pytest.raises(ValueError, match="0"):
+            fuzzy_country("United", max_results=0)
+
+    def test_max_results_negative_large_raises(self) -> None:
+        """Any negative integer must raise regardless of magnitude."""
+        import pytest
+
+        with pytest.raises(ValueError):
+            fuzzy_country("United", max_results=-100)
+
+    def test_returns_tuple_not_list(self) -> None:
+        """Return type must be tuple, not list, to satisfy the type signature."""
+        result = fuzzy_country("France")
+        assert isinstance(result, tuple)
+
+    def test_each_match_is_country_info(self) -> None:
+        """Every element returned must be a CountryInfo dataclass instance."""
+        matches = fuzzy_country("Germany", max_results=2)
+        for m in matches:
+            assert isinstance(m, CountryInfo)
+            assert m.alpha_2  # non-empty
+
+
+class TestLookupCountryAdditional:
+    """Additional lookup_country tests for lru_cache switch."""
+
+    def test_returns_country_info_dataclass(self) -> None:
+        """lookup_country result must be a CountryInfo with populated fields."""
+        info = lookup_country("DE")
+        assert info is not None
+        assert isinstance(info, CountryInfo)
+        assert info.alpha_2 == "DE"
+        assert info.alpha_3 == "DEU"
+        assert info.name  # non-empty
+
+    def test_whitespace_stripped_before_lookup(self) -> None:
+        """Leading/trailing whitespace around the key is normalised."""
+        info_plain = lookup_country("US")
+        info_padded = lookup_country("  US  ")
+        assert info_padded is not None
+        assert info_padded.alpha_2 == info_plain.alpha_2  # type: ignore[union-attr]
+
+    def test_official_name_field_exists(self) -> None:
+        """CountryInfo dataclass must expose official_name (str | None)."""
+        info = lookup_country("IR")
+        assert info is not None
+        assert hasattr(info, "official_name")
+
+    def test_result_is_frozen(self) -> None:
+        """CountryInfo is a frozen dataclass — mutation must raise."""
+        import pytest
+
+        info = lookup_country("GB")
+        assert info is not None
+        with pytest.raises((AttributeError, TypeError)):
+            info.alpha_2 = "XX"  # type: ignore[misc]

--- a/lexnlp/extract/en/citation_variations.py
+++ b/lexnlp/extract/en/citation_variations.py
@@ -34,6 +34,9 @@ try:
     from reporters_db import VARIATIONS_ONLY as _VARIATIONS_RAW
 except ImportError:  # pragma: no cover
     try:
+        # type: ignore[attr-defined] — older ``reporters_db`` releases expose
+        # the dictionary as ``VARIATIONS`` instead of ``VARIATIONS_ONLY``;
+        # the fallback is intentional and not declared in modern stubs.
         from reporters_db import VARIATIONS as _VARIATIONS_RAW  # type: ignore[attr-defined]
     except ImportError:  # pragma: no cover
         _VARIATIONS_RAW = {}
@@ -58,6 +61,16 @@ def variation_map() -> dict[str, tuple[str, ...]]:
     return result
 
 
+@lru_cache(maxsize=1)
+def _normalized_variation_index() -> dict[str, tuple[str, ...]]:
+    """Pre-built whitespace-stripped index used by :func:`canonical_for`.
+
+    Avoids the O(n) per-call scan of ``variation_map()`` for the common
+    "user typed extra spaces around a period" case.
+    """
+    return {variation.replace(" ", ""): canons for variation, canons in variation_map().items()}
+
+
 def canonical_for(variant: str) -> tuple[str, ...]:
     """Return the canonical citation(s) for a given variant.
 
@@ -72,12 +85,9 @@ def canonical_for(variant: str) -> tuple[str, ...]:
     direct = variation_map().get(variant)
     if direct is not None:
         return direct
-    # Mild normalization: strip whitespace around "." segments.
-    normalized = variant.replace(" ", "")
-    for variation, canons in variation_map().items():
-        if variation.replace(" ", "") == normalized:
-            return canons
-    return ()
+    # Mild normalization: strip whitespace around "." segments. Use the
+    # pre-built index so this stays an O(1) hash lookup.
+    return _normalized_variation_index().get(variant.replace(" ", ""), ())
 
 
 def is_known_reporter(name: str) -> bool:

--- a/lexnlp/extract/en/tests/test_citation_variations.py
+++ b/lexnlp/extract/en/tests/test_citation_variations.py
@@ -59,3 +59,114 @@ class TestNormalizeReporter:
 
     def test_returns_input_unchanged_when_empty(self) -> None:
         assert normalize_reporter("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for PR changes: _normalized_variation_index
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizedVariationIndex:
+    """Tests for the new pre-built whitespace-stripped index added by the PR."""
+
+    def test_index_is_consistent_with_variation_map(self) -> None:
+        """The stripped index must contain exactly the same entries as
+        variation_map() after stripping spaces from keys."""
+        from lexnlp.extract.en.citation_variations import (
+            _normalized_variation_index,
+            variation_map,
+        )
+
+        vm = variation_map()
+        index = _normalized_variation_index()
+        # Every variation_map key, when stripped of spaces, must appear in the index.
+        for variation, canons in vm.items():
+            stripped = variation.replace(" ", "")
+            # The index may merge multiple original keys that normalise to the
+            # same stripped form; the expected canons are a subset of index values.
+            assert stripped in index, (
+                f"Stripped key '{stripped}' (from '{variation}') missing from index"
+            )
+
+    def test_index_values_are_tuples(self) -> None:
+        """All values in the index must be tuples of strings."""
+        from lexnlp.extract.en.citation_variations import _normalized_variation_index
+
+        index = _normalized_variation_index()
+        for key, canons in index.items():
+            assert isinstance(canons, tuple), f"Value for '{key}' is not a tuple: {canons!r}"
+            for c in canons:
+                assert isinstance(c, str), f"Non-str canonical '{c!r}' for key '{key}'"
+
+    def test_index_is_non_empty(self) -> None:
+        """If reporters_db has variations, the index must be non-empty."""
+        from lexnlp.extract.en.citation_variations import (
+            _normalized_variation_index,
+            variation_map,
+        )
+
+        if variation_map():  # only assert when the db has content
+            assert len(_normalized_variation_index()) > 0
+
+    def test_canonical_for_result_matches_index_lookup(self) -> None:
+        """canonical_for must agree with a direct _normalized_variation_index lookup."""
+        from lexnlp.extract.en.citation_variations import (
+            _normalized_variation_index,
+            canonical_for,
+        )
+
+        index = _normalized_variation_index()
+        if not index:
+            return  # reporters_db not available
+        # Take a key from the index (already stripped of spaces) and wrap it
+        # in spaces so canonical_for exercises the normalization path.
+        stripped_key = next(iter(index))
+        spaced_key = " ".join(stripped_key)  # add spaces between every char
+        result = canonical_for(spaced_key)
+        expected = index[stripped_key]
+        assert result == expected, (
+            f"canonical_for('{spaced_key}') → {result!r}, "
+            f"but index['{stripped_key}'] → {expected!r}"
+        )
+
+
+class TestCanonicalForAdditional:
+    """Additional canonical_for tests for the O(1) lookup refactor."""
+
+    def test_result_is_always_tuple(self) -> None:
+        """canonical_for must always return a tuple, never None."""
+        for variant in ("", "TotallyUnknown", "U.S.", "U. S."):
+            result = canonical_for(variant)
+            assert isinstance(result, tuple), (
+                f"canonical_for('{variant}') returned {type(result).__name__}, expected tuple"
+            )
+
+    def test_known_variant_returns_non_empty_tuple(self) -> None:
+        """For a variant that exists in the db, the result must be non-empty."""
+        from lexnlp.extract.en.citation_variations import variation_map
+
+        vm = variation_map()
+        if not vm:
+            return  # reporters_db empty
+        # Pick the first known variant
+        known = next(iter(vm))
+        result = canonical_for(known)
+        assert len(result) > 0, f"canonical_for('{known}') returned empty tuple"
+
+    def test_space_normalization_is_idempotent(self) -> None:
+        """Adding extra spaces around dots in a known variant must still resolve."""
+        from lexnlp.extract.en.citation_variations import variation_map
+
+        vm = variation_map()
+        if not vm:
+            return
+        known = next(iter(vm))
+        # Add spaces around every "." in the known variant.
+        spaced = known.replace(".", " . ")
+        result_spaced = canonical_for(spaced)
+        result_direct = canonical_for(known)
+        # Both should resolve to the same canons (both strip spaces internally).
+        assert result_spaced == result_direct, (
+            f"Space-padded variant '{spaced}' → {result_spaced!r} differs from "
+            f"direct '{known}' → {result_direct!r}"
+        )

--- a/lexnlp/ml/catalog/hub.py
+++ b/lexnlp/ml/catalog/hub.py
@@ -65,16 +65,13 @@ def get_path_from_hub(
         hub = importlib.import_module("huggingface_hub")
     except ImportError as exc:
         raise HubUnavailableError(
-            "huggingface_hub is not installed. Install with "
-            "`uv pip install lexnlp[hub]`."
+            "huggingface_hub is not installed. Install with `uv pip install lexnlp[hub]`."
         ) from exc
 
     try:
         local = hub.hf_hub_download(repo_id=repo_id, filename=tag, revision=revision)
     except Exception as exc:  # noqa: BLE001 — upstream error surface is broad
-        raise HubMirrorError(
-            f"Failed to fetch '{tag}' from Hub repo '{repo_id}': {exc}"
-        ) from exc
+        raise HubMirrorError(f"Failed to fetch '{tag}' from Hub repo '{repo_id}': {exc}") from exc
     return Path(local)
 
 

--- a/lexnlp/ml/catalog/tests/test_hub.py
+++ b/lexnlp/ml/catalog/tests/test_hub.py
@@ -6,7 +6,9 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
+import types
 from pathlib import Path
+from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -19,6 +21,20 @@ from lexnlp.ml.catalog.hub import (
 )
 
 
+def _fake_hub_module(downloader: Any) -> types.ModuleType:
+    """Return a fake ``huggingface_hub`` test double.
+
+    Uses ``setattr`` to attach ``hf_hub_download`` to a ``ModuleType``,
+    sidestepping the ``# type: ignore[attr-defined]`` suppression that
+    direct attribute assignment would otherwise require. Ruff's B010
+    nudges us toward direct assignment, but here that path is what we
+    are explicitly avoiding to keep the test type-clean.
+    """
+    fake = types.ModuleType("huggingface_hub")
+    setattr(fake, "hf_hub_download", downloader)  # noqa: B010 — see docstring.
+    return fake
+
+
 class TestHubAvailability(TestCase):
     def test_returns_false_when_huggingface_hub_missing(self) -> None:
         """When huggingface_hub is not installed the probe reports False
@@ -27,10 +43,7 @@ class TestHubAvailability(TestCase):
             self.assertFalse(hub_is_available())
 
     def test_returns_true_when_import_works(self) -> None:
-        import types
-
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = lambda **kwargs: "/tmp/fake"  # type: ignore[attr-defined]
+        fake = _fake_hub_module(lambda **kwargs: "/tmp/fake")
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             self.assertTrue(hub_is_available())
 
@@ -42,16 +55,13 @@ class TestGetPathFromHub(TestCase):
                 get_path_from_hub("some-tag")
 
     def test_calls_hf_hub_download_with_default_repo(self) -> None:
-        import types
-
         calls: list[dict] = []
 
         def fake_download(**kwargs):
             calls.append(kwargs)
             return "/tmp/mock/path"
 
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = fake_download  # type: ignore[attr-defined]
+        fake = _fake_hub_module(fake_download)
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             result = get_path_from_hub("addresses_clf")
         self.assertEqual(result, Path("/tmp/mock/path"))
@@ -60,52 +70,40 @@ class TestGetPathFromHub(TestCase):
         self.assertEqual(calls[0]["filename"], "addresses_clf")
 
     def test_forwards_revision(self) -> None:
-        import types
-
         calls: list[dict] = []
 
         def fake_download(**kwargs):
             calls.append(kwargs)
             return "/tmp/rev"
 
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = fake_download  # type: ignore[attr-defined]
+        fake = _fake_hub_module(fake_download)
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             get_path_from_hub("tag", revision="v2.3.0")
         self.assertEqual(calls[0]["revision"], "v2.3.0")
 
     def test_honours_custom_repo_id(self) -> None:
-        import types
-
         calls: list[dict] = []
 
         def fake_download(**kwargs):
             calls.append(kwargs)
             return "/tmp/custom"
 
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = fake_download  # type: ignore[attr-defined]
+        fake = _fake_hub_module(fake_download)
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             get_path_from_hub("tag", repo_id="my-org/my-models")
         self.assertEqual(calls[0]["repo_id"], "my-org/my-models")
 
     def test_returns_pathlib_path(self) -> None:
-        import types
-
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = lambda **kwargs: "/tmp/abc"  # type: ignore[attr-defined]
+        fake = _fake_hub_module(lambda **kwargs: "/tmp/abc")
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             result = get_path_from_hub("tag")
         self.assertIsInstance(result, Path)
 
     def test_wraps_hub_errors(self) -> None:
-        import types
-
         def fake_download(**kwargs):
             raise RuntimeError("404 not found")
 
-        fake = types.ModuleType("huggingface_hub")
-        fake.hf_hub_download = fake_download  # type: ignore[attr-defined]
+        fake = _fake_hub_module(fake_download)
         with patch.dict("sys.modules", {"huggingface_hub": fake}):
             with self.assertRaises(HubMirrorError):
                 get_path_from_hub("missing-tag")

--- a/lexnlp/ml/model_card.py
+++ b/lexnlp/ml/model_card.py
@@ -71,9 +71,15 @@ def write_model_card(
     if metadata.authors:
         c.add(authors=metadata.authors)
     if metadata.tags:
+        # ``Card.add`` accepts string-valued sections only, so render the
+        # tag tuple as a comma-separated list. Each tag remains visible in
+        # the final markdown card.
         c.add(tags=", ".join(metadata.tags))
     if metrics:
-        c.add_metrics(**{k: str(v) for k, v in metrics.items()})
+        # ``Card.add_metrics`` already accepts ``str | int | float``; pass
+        # numbers through unchanged so the rendered table preserves the
+        # caller's original precision.
+        c.add_metrics(**metrics)
     dest.write_text(c.render(), encoding="utf-8")
     return dest
 

--- a/lexnlp/ml/model_io.py
+++ b/lexnlp/ml/model_io.py
@@ -116,11 +116,17 @@ def _load_legacy(path: Path) -> Any:
             try:
                 with _patched_sklearn_tree_loader():
                     return _patch_legacy_sklearn_estimator(pickle.load(file))
-            except (pickle.UnpicklingError, ValueError, EOFError, AttributeError):
-                if not _looks_like_joblib_pickle(path):
-                    raise
+            except (pickle.UnpicklingError, ValueError, EOFError, AttributeError) as exc:
+                # Older joblib payloads — including ``compress=0`` ones that do
+                # NOT start with the zlib framing byte — can fail the raw
+                # ``pickle.load`` path because joblib prepends its own header.
+                # Always retry via the joblib loader and only re-raise the
+                # original exception if joblib also rejects the file.
                 LOGGER.debug("Falling back to joblib-compatible legacy loader: %s", path)
-        return _load_legacy_joblib(path)
+                try:
+                    return _load_legacy_joblib(path)
+                except Exception:
+                    raise exc
     if suffix == ".cloudpickle":
         from cloudpickle import load as cloudpickle_load
 
@@ -142,13 +148,6 @@ def _load_legacy_joblib(path: Path) -> Any:
 
     with _patched_sklearn_tree_loader():
         return _patch_legacy_sklearn_estimator(joblib.load(path))
-
-
-def _looks_like_joblib_pickle(path: Path) -> bool:
-    """Return ``True`` when a legacy ``.pickle`` file looks joblib-compressed."""
-
-    with path.open("rb") as file:
-        return file.read(1) == b"\x78"
 
 
 def _patch_legacy_sklearn_estimator(obj: Any, _seen: set[int] | None = None) -> Any:
@@ -303,12 +302,13 @@ def _load_skops(
     past the skops gate even with ``trusted=True``.
     """
 
-    declared = list(get_untrusted_types(file=path) or [])
     if not trusted:
         # Fail-closed path: hand an empty list so skops enforces its own
         # default trusted set and raises UntrustedTypesFoundException.
+        # Avoid scanning the artifact's declared types on this common path.
         return _skops_load(path, trusted=[])
 
+    declared = list(get_untrusted_types(file=path) or [])
     allowed = DEFAULT_TRUSTED_ALLOWLIST | frozenset(extra_trusted)
     rejected = [name for name in declared if name not in allowed]
     if rejected:

--- a/lexnlp/ml/tests/test_model_card.py
+++ b/lexnlp/ml/tests/test_model_card.py
@@ -139,3 +139,104 @@ class TestModelCardMetadataValidation(TestCase):
     def test_tags_default_is_empty_tuple(self) -> None:
         md = ModelCardMetadata(description="x")
         self.assertEqual(md.tags, ())
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for PR changes: tags rendering and metric precision
+# ---------------------------------------------------------------------------
+
+
+class TestWriteModelCardAdditional(TestCase):
+    """Additional tests that extend coverage of the PR-specific changes to
+    write_model_card (tags as comma-separated, metrics as numeric)."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmpdir = Path(self.tmp.name)
+
+    def _fitted_estimator(self):
+        from sklearn.linear_model import LogisticRegression
+
+        clf = LogisticRegression(max_iter=50, solver="lbfgs")
+        clf.fit([[0.0], [1.0]], [0, 1])
+        return clf
+
+    def test_single_tag_renders_without_comma(self) -> None:
+        """A tuple with exactly one tag must render without a trailing comma."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x", tags=("solo",))
+        out = write_model_card(clf, self.tmpdir / "single_tag.md", metadata=md)
+        content = out.read_text(encoding="utf-8")
+        self.assertIn("solo", content)
+        # The join of a single-element tuple produces no comma.
+        # "solo," would indicate incorrect handling.
+        self.assertNotIn("solo,", content)
+
+    def test_three_tags_all_render(self) -> None:
+        """All three tags in a 3-element tuple must appear in the card."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(
+            description="x",
+            tags=("legal", "nlp", "en"),
+        )
+        out = write_model_card(clf, self.tmpdir / "three_tags.md", metadata=md)
+        content = out.read_text(encoding="utf-8")
+        for tag in ("legal", "nlp", "en"):
+            self.assertIn(tag, content)
+
+    def test_empty_tags_no_tag_section(self) -> None:
+        """When tags is empty the card is written without crashing."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x", tags=())
+        out = write_model_card(clf, self.tmpdir / "no_tags.md", metadata=md)
+        self.assertTrue(out.exists())
+
+    def test_metrics_integer_value_renders(self) -> None:
+        """Integer metric values must survive the no-string-coercion path."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x")
+        out = write_model_card(
+            clf,
+            self.tmpdir / "int_metrics.md",
+            metadata=md,
+            metrics={"n_samples": 1000},
+        )
+        content = out.read_text(encoding="utf-8")
+        self.assertIn("1000", content)
+
+    def test_creates_nested_parent_directory(self) -> None:
+        """write_model_card must create any missing parent directories."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x")
+        deep_path = self.tmpdir / "a" / "b" / "c" / "card.md"
+        out = write_model_card(clf, deep_path, metadata=md)
+        self.assertTrue(out.exists())
+        self.assertEqual(out.suffix, ".md")
+
+    def test_suffix_normalised_to_md(self) -> None:
+        """Passing a path without .md suffix must still produce a .md file."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x")
+        out = write_model_card(clf, self.tmpdir / "card.txt", metadata=md)
+        self.assertEqual(out.suffix, ".md")
+
+    def test_multiple_metrics_all_render(self) -> None:
+        """Every metric key and value must appear in the rendered card."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x")
+        metrics = {"precision": 0.9, "recall": 0.8, "f1": 0.85}
+        out = write_model_card(clf, self.tmpdir / "multi.md", metadata=md, metrics=metrics)
+        content = out.read_text(encoding="utf-8")
+        for key, val in metrics.items():
+            self.assertIn(key, content)
+            self.assertIn(str(val), content)
+
+    def test_no_metrics_does_not_crash(self) -> None:
+        """write_model_card with metrics=None must succeed silently."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="bare")
+        out = write_model_card(clf, self.tmpdir / "bare.md", metadata=md, metrics=None)
+        self.assertTrue(out.exists())

--- a/lexnlp/ml/tests/test_model_card.py
+++ b/lexnlp/ml/tests/test_model_card.py
@@ -67,6 +67,35 @@ class TestWriteModelCard(TestCase):
         self.assertIn("accuracy", content)
         self.assertIn("0.91", content)
 
+    def test_card_tags_render_each_value(self) -> None:
+        """Every tag in ``ModelCardMetadata.tags`` surfaces in the final
+        rendered card, not just the first one."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(
+            description="x",
+            license="",
+            authors="",
+            tags=("legal", "classifier"),
+        )
+        out = write_model_card(clf, self.tmpdir / "tagged.md", metadata=md)
+        content = out.read_text(encoding="utf-8")
+        self.assertIn("legal", content)
+        self.assertIn("classifier", content)
+
+    def test_card_metrics_keep_numeric_precision(self) -> None:
+        """Numeric metric values must reach ``Card.add_metrics`` unchanged,
+        so the rendered card preserves the caller's precision."""
+        clf = self._fitted_estimator()
+        md = ModelCardMetadata(description="x", license="", authors="")
+        out = write_model_card(
+            clf,
+            self.tmpdir / "metrics.md",
+            metadata=md,
+            metrics={"accuracy": 0.123456},
+        )
+        content = out.read_text(encoding="utf-8")
+        self.assertIn("0.123456", content)
+
     def test_dump_model_with_card_writes_both_artifacts(self) -> None:
         clf = self._fitted_estimator()
         md = ModelCardMetadata(description="x", license="", authors="")
@@ -96,9 +125,17 @@ class TestWriteModelCard(TestCase):
 class TestModelCardMetadataValidation(TestCase):
     def test_required_description(self) -> None:
         with self.assertRaises((TypeError, ValueError)):
+            # type: ignore[call-arg] — intentionally omitting the required
+            # ``description`` field to assert the runtime constructor fails.
             ModelCardMetadata()  # type: ignore[call-arg]
 
     def test_frozen(self) -> None:
         md = ModelCardMetadata(description="x", license="", authors="")
         with self.assertRaises((AttributeError, Exception)):
+            # type: ignore[misc] — intentionally mutating a frozen dataclass
+            # attribute to assert immutability is enforced at runtime.
             md.description = "changed"  # type: ignore[misc]
+
+    def test_tags_default_is_empty_tuple(self) -> None:
+        md = ModelCardMetadata(description="x")
+        self.assertEqual(md.tags, ())

--- a/lexnlp/ml/tests/test_model_io.py
+++ b/lexnlp/ml/tests/test_model_io.py
@@ -176,6 +176,16 @@ class TestLoadLegacy:
         joblib.dump({"jl_pickle": True}, path, compress=3)
         assert _load_legacy(path) == {"jl_pickle": True}
 
+    def test_loads_joblib_uncompressed_pickle_file(self, tmp_path: Path) -> None:
+        """Regression: a ``.pickle`` written by ``joblib.dump(..., compress=0)``
+        must still load via the joblib fallback even though it does not
+        start with the zlib framing byte."""
+        import joblib
+
+        path = tmp_path / "model_uncompressed.pickle"
+        joblib.dump({"jl_pickle_raw": True}, path, compress=0)
+        assert _load_legacy(path) == {"jl_pickle_raw": True}
+
     def test_unknown_suffix_raises_value_error(self, tmp_path: Path) -> None:
         """Unknown extensions must be rejected rather than blindly pickle-loaded."""
         path = tmp_path / "model.bin"
@@ -324,7 +334,8 @@ class TestTrustedAllowlist:
 
     def test_load_rejects_type_outside_allowlist(self, tmp_path: Path) -> None:
         """trusted=True without override rejects artifacts containing a
-        type that is not in DEFAULT_TRUSTED_ALLOWLIST."""
+        type that is not in DEFAULT_TRUSTED_ALLOWLIST, raising
+        ``ValueError`` whose message names the rejected type."""
 
         path = dump_model({"x": 1}, tmp_path / "m.skops")
         # Inject a fake untrusted type by patching get_untrusted_types.
@@ -332,16 +343,44 @@ class TestTrustedAllowlist:
             "lexnlp.ml.model_io.get_untrusted_types",
             return_value=["evil.Module.RemoteCodeExecution"],
         ):
-            with pytest.raises(Exception):  # noqa: B017 - skops raises its own
+            with pytest.raises(ValueError, match="trusted allow-list") as excinfo:
                 _load_skops(path, trusted=True)
+        assert "evil.Module.RemoteCodeExecution" in str(excinfo.value)
 
     def test_load_accepts_additional_allowed_type(self, tmp_path: Path) -> None:
-        """Callers may extend the allow-list with extra type names."""
+        """Callers may extend the allow-list with extra type names so a
+        previously rejected custom type is accepted."""
 
         path = dump_model({"x": 1}, tmp_path / "m.skops")
-        # No untrusted types are actually present; call should succeed.
-        result = _load_skops(path, trusted=True, extra_trusted=("my.Custom.Class",))
+        captured: dict[str, list[str]] = {}
+
+        # Real artifact contains no custom types, so to prove ``extra_trusted``
+        # actually flows into the skops gate we (a) stub ``get_untrusted_types``
+        # to return the allow-listed name and (b) intercept ``_skops_load`` to
+        # capture the trusted list it was invoked with.
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+            captured["trusted"] = list(trusted)
+            return {"x": 1}
+
+        with (
+            patch(
+                "lexnlp.ml.model_io.get_untrusted_types",
+                return_value=["my.Custom.Class"],
+            ),
+            patch("lexnlp.ml.model_io._skops_load", side_effect=fake_skops_load),
+        ):
+            result = _load_skops(path, trusted=True, extra_trusted=("my.Custom.Class",))
         assert result == {"x": 1}
+        assert captured["trusted"] == ["my.Custom.Class"]
+
+    def test_load_skips_get_untrusted_types_when_not_trusted(self, tmp_path: Path) -> None:
+        """The fail-closed path must not pay the cost of scanning declared
+        types — ``get_untrusted_types`` is only called when ``trusted=True``."""
+
+        path = dump_model({"x": 1}, tmp_path / "m.skops")
+        with patch("lexnlp.ml.model_io.get_untrusted_types") as mock_gut:
+            _load_skops(path, trusted=False)
+        mock_gut.assert_not_called()
 
 
 class TestConstants:

--- a/lexnlp/ml/tests/test_model_io.py
+++ b/lexnlp/ml/tests/test_model_io.py
@@ -358,7 +358,7 @@ class TestTrustedAllowlist:
         # actually flows into the skops gate we (a) stub ``get_untrusted_types``
         # to return the allow-listed name and (b) intercept ``_skops_load`` to
         # capture the trusted list it was invoked with.
-        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]  # test stub: simple dict return, typing not needed
             captured["trusted"] = list(trusted)
             return {"x": 1}
 
@@ -504,7 +504,7 @@ class TestLoadSkopsAdditional:
         custom_type = "my.domain.SpecialEncoder"
         assert custom_type not in DEFAULT_TRUSTED_ALLOWLIST
 
-        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]  # test stub: simple dict return, typing not needed
             return {"ok": 1}
 
         with (
@@ -523,7 +523,7 @@ class TestLoadSkopsAdditional:
         known_safe = "numpy.ndarray"
         assert known_safe in DEFAULT_TRUSTED_ALLOWLIST
 
-        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]  # test stub: simple dict return, typing not needed
             return {"ok": 1}
 
         with (

--- a/lexnlp/ml/tests/test_model_io.py
+++ b/lexnlp/ml/tests/test_model_io.py
@@ -401,3 +401,137 @@ class TestConstants:
 
     def test_legacy_suffixes_is_frozenset(self) -> None:
         assert isinstance(_LEGACY_SUFFIXES, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for PR changes to _load_legacy and _load_skops
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLegacyAdditional:
+    """Additional tests for the PR-refactored _load_legacy helper."""
+
+    def test_double_failure_reraises_original_pickle_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """When both the raw pickle path AND the joblib fallback fail, the
+        original pickle exception (not the joblib one) must propagate.
+
+        The PR removed _looks_like_joblib_pickle and always retries via joblib.
+        When joblib also fails, the original pickle exception is re-raised.
+        """
+        path = tmp_path / "corrupt.pickle"
+        path.write_bytes(b"not a pickle and not a joblib file")
+        with pytest.raises(Exception):
+            _load_legacy(path)
+
+    def test_joblib_compress_0_round_trips_via_pickle_extension(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: joblib.dump(obj, path, compress=0) produces a file that
+        does NOT start with the zlib framing byte.  The old guard (_looks_like_
+        joblib_pickle) would have blocked the fallback; the PR always retries."""
+        import joblib
+
+        path = tmp_path / "raw_joblib.pickle"
+        obj = {"compress_level": 0, "data": list(range(10))}
+        joblib.dump(obj, path, compress=0)
+        result = _load_legacy(path)
+        assert result == obj
+
+    def test_loads_pkl_extension_via_joblib_fallback(self, tmp_path: Path) -> None:
+        """A .pkl file written by joblib must load via the joblib fallback."""
+        import joblib
+
+        path = tmp_path / "model.pkl"
+        joblib.dump({"via": "joblib"}, path, compress=3)
+        result = _load_legacy(path)
+        assert result == {"via": "joblib"}
+
+    def test_looks_like_joblib_pickle_function_removed(self) -> None:
+        """The PR removed _looks_like_joblib_pickle — it must not exist."""
+        import lexnlp.ml.model_io as model_io_module
+
+        assert not hasattr(model_io_module, "_looks_like_joblib_pickle"), (
+            "_looks_like_joblib_pickle was removed by the PR and must not be present"
+        )
+
+
+class TestLoadSkopsAdditional:
+    """Additional tests for the PR-refactored _load_skops helper."""
+
+    def test_trusted_false_does_not_call_get_untrusted_types(
+        self, tmp_path: Path
+    ) -> None:
+        """The fail-closed (trusted=False) path must skip the type scan entirely."""
+        path = dump_model({"ok": True}, tmp_path / "m.skops")
+        with patch("lexnlp.ml.model_io.get_untrusted_types") as mock_gut:
+            result = _load_skops(path, trusted=False)
+        mock_gut.assert_not_called()
+        assert result == {"ok": True}
+
+    def test_trusted_true_calls_get_untrusted_types_exactly_once(
+        self, tmp_path: Path
+    ) -> None:
+        """When trusted=True the artifact is scanned exactly once."""
+        path = dump_model({"ok": True}, tmp_path / "m.skops")
+        with patch(
+            "lexnlp.ml.model_io.get_untrusted_types", return_value=[]
+        ) as mock_gut:
+            _load_skops(path, trusted=True)
+        mock_gut.assert_called_once_with(file=path)
+
+    def test_rejection_message_lists_all_rejected_types(
+        self, tmp_path: Path
+    ) -> None:
+        """When multiple types are outside the allowlist, all must appear
+        in the ValueError message."""
+        path = dump_model({"ok": 1}, tmp_path / "m.skops")
+        bad_types = ["evil.A", "evil.B", "evil.C"]
+        with patch(
+            "lexnlp.ml.model_io.get_untrusted_types",
+            return_value=bad_types,
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                _load_skops(path, trusted=True)
+        msg = str(excinfo.value)
+        for t in bad_types:
+            assert t in msg, f"Type '{t}' missing from rejection message: {msg}"
+
+    def test_extra_trusted_extends_allow_list(self, tmp_path: Path) -> None:
+        """extra_trusted types not in DEFAULT_TRUSTED_ALLOWLIST must be accepted."""
+        path = dump_model({"ok": 1}, tmp_path / "m.skops")
+        custom_type = "my.domain.SpecialEncoder"
+        assert custom_type not in DEFAULT_TRUSTED_ALLOWLIST
+
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+            return {"ok": 1}
+
+        with (
+            patch(
+                "lexnlp.ml.model_io.get_untrusted_types",
+                return_value=[custom_type],
+            ),
+            patch("lexnlp.ml.model_io._skops_load", side_effect=fake_skops_load),
+        ):
+            result = _load_skops(path, trusted=True, extra_trusted=(custom_type,))
+        assert result == {"ok": 1}
+
+    def test_type_in_default_allowlist_not_rejected(self, tmp_path: Path) -> None:
+        """A type already in DEFAULT_TRUSTED_ALLOWLIST must not be rejected."""
+        path = dump_model({"ok": 1}, tmp_path / "m.skops")
+        known_safe = "numpy.ndarray"
+        assert known_safe in DEFAULT_TRUSTED_ALLOWLIST
+
+        def fake_skops_load(p, trusted):  # type: ignore[no-untyped-def]
+            return {"ok": 1}
+
+        with (
+            patch(
+                "lexnlp.ml.model_io.get_untrusted_types",
+                return_value=[known_safe],
+            ),
+            patch("lexnlp.ml.model_io._skops_load", side_effect=fake_skops_load),
+        ):
+            result = _load_skops(path, trusted=True)
+        assert result == {"ok": 1}

--- a/lexnlp/ml/tests/test_sklearn_config.py
+++ b/lexnlp/ml/tests/test_sklearn_config.py
@@ -71,8 +71,12 @@ class TestEnableMetadataRouting:
             set_config(enable_metadata_routing=previous)
 
     def test_returns_previous_value(self) -> None:
-        from sklearn import set_config
+        from sklearn import get_config, set_config
 
+        # Snapshot the original global state so we restore it verbatim
+        # rather than hard-coding ``False`` (which would leak into any
+        # later test that relies on the prior value).
+        original = get_config().get("enable_metadata_routing", False)
         set_config(enable_metadata_routing=False)
         try:
             previous = enable_metadata_routing()
@@ -81,7 +85,7 @@ class TestEnableMetadataRouting:
             # The call flipped True→True, so the "previous" now reports True
             assert next_prev is True
         finally:
-            set_config(enable_metadata_routing=False)
+            set_config(enable_metadata_routing=original)
 
 
 class TestConfigurePipeline:

--- a/lexnlp/utils/caching.py
+++ b/lexnlp/utils/caching.py
@@ -63,6 +63,10 @@ def cache[F: Callable[..., Any]](func: F) -> F:
     can swap between in-memory and on-disk caching by changing one
     decorator.
     """
+    # type: ignore[return-value] — joblib.Memory.cache returns a
+    # ``MemorizedFunc`` wrapper that mimics ``func`` at runtime but is not
+    # statically a subtype of ``F``; the decorator's contract is that the
+    # call signature is preserved, which the wrapper honours.
     return get_memory().cache(func)  # type: ignore[return-value]
 
 

--- a/lexnlp/utils/cosine.py
+++ b/lexnlp/utils/cosine.py
@@ -25,11 +25,13 @@ def cosine_similarity(a: ArrayLike | Sequence[float], b: ArrayLike | Sequence[fl
     """Return the cosine similarity between two 1-D vectors.
 
     Returns ``0.0`` when either vector has zero magnitude rather than
-    raising or producing ``NaN``. Raises :class:`ValueError` if the two
-    vectors have different lengths.
+    raising or producing ``NaN``. Raises :class:`ValueError` if either
+    input is not 1-D or if the two vectors have different lengths.
     """
     va: NDArray[np.floating] = np.asarray(a, dtype=np.float64)
     vb: NDArray[np.floating] = np.asarray(b, dtype=np.float64)
+    if va.ndim != 1 or vb.ndim != 1:
+        raise ValueError(f"cosine_similarity expects 1-D vectors, got shapes {va.shape} and {vb.shape}")
     if va.shape != vb.shape:
         raise ValueError(f"shape mismatch: {va.shape} vs {vb.shape}")
     na = float(np.linalg.norm(va))

--- a/lexnlp/utils/tests/test_cosine.py
+++ b/lexnlp/utils/tests/test_cosine.py
@@ -51,6 +51,21 @@ class TestCosineSimilarity(TestCase):
         with self.assertRaises(ValueError):
             cosine_similarity(np.array([1.0, 2.0]), np.array([1.0, 2.0, 3.0]))
 
+    def test_rejects_2d_inputs(self):
+        """Same-shape 2-D arrays must raise rather than crash inside
+        ``float()`` because ``np.vecdot`` returns an array on rank > 1
+        inputs."""
+        a = np.ones((2, 2), dtype=np.float64)
+        b = np.ones((2, 2), dtype=np.float64)
+        with self.assertRaisesRegex(ValueError, "1-D vectors"):
+            cosine_similarity(a, b)
+
+    def test_rejects_one_2d_input(self):
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.array([[1.0, 2.0, 3.0]])
+        with self.assertRaisesRegex(ValueError, "1-D vectors"):
+            cosine_similarity(a, b)
+
     def test_is_finite(self):
         result = cosine_similarity(np.array([1.0, 2.0, 3.0]), np.array([3.0, 2.0, 1.0]))
         self.assertTrue(math.isfinite(result))

--- a/lexnlp/utils/tests/test_cosine.py
+++ b/lexnlp/utils/tests/test_cosine.py
@@ -69,3 +69,38 @@ class TestCosineSimilarity(TestCase):
     def test_is_finite(self):
         result = cosine_similarity(np.array([1.0, 2.0, 3.0]), np.array([3.0, 2.0, 1.0]))
         self.assertTrue(math.isfinite(result))
+
+    # -----------------------------------------------------------------------
+    # Additional tests for PR change: 1-D validation guard
+    # -----------------------------------------------------------------------
+
+    def test_rejects_0d_scalar_input(self):
+        """A 0-D array (scalar) must raise ValueError with a 1-D vectors message."""
+        a = np.array(1.0)  # 0-D
+        b = np.array(2.0)  # 0-D
+        with self.assertRaisesRegex(ValueError, "1-D vectors"):
+            cosine_similarity(a, b)
+
+    def test_rejects_mixed_0d_and_1d(self):
+        """Mixing a 0-D scalar with a 1-D vector must also raise."""
+        with self.assertRaisesRegex(ValueError, "1-D vectors"):
+            cosine_similarity(np.array(1.0), np.array([1.0, 2.0]))
+
+    def test_rejects_3d_input(self):
+        """3-D arrays must raise, not silently compute something unexpected."""
+        a = np.ones((2, 2, 2), dtype=np.float64)
+        b = np.ones((2, 2, 2), dtype=np.float64)
+        with self.assertRaisesRegex(ValueError, "1-D vectors"):
+            cosine_similarity(a, b)
+
+    def test_error_message_includes_shapes(self):
+        """The ValueError for shape mismatch must include both shapes."""
+        with self.assertRaises(ValueError) as ctx:
+            cosine_similarity(np.array([1.0, 2.0]), np.array([1.0, 2.0, 3.0]))
+        self.assertIn("(2,)", str(ctx.exception))
+        self.assertIn("(3,)", str(ctx.exception))
+
+    def test_return_type_is_float(self):
+        """cosine_similarity must return a plain Python float, not a numpy scalar."""
+        result = cosine_similarity(np.array([1.0, 0.0]), np.array([0.0, 1.0]))
+        self.assertIsInstance(result, float)

--- a/lexnlp/utils/tests/test_pandas_config_read_csv.py
+++ b/lexnlp/utils/tests/test_pandas_config_read_csv.py
@@ -8,6 +8,7 @@ __email__ = "support@contraxsuite.com"
 
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -22,8 +23,7 @@ class TestReadCsvArrow(TestCase):
         self.addCleanup(self.tmp.cleanup)
         self.path = Path(self.tmp.name) / "sample.csv"
         self.path.write_text(
-            "alias,name,country\nSTF,Supremo Tribunal Federal,Brazil\n"
-            "TSE,Tribunal Superior Eleitoral,Brazil\n",
+            "alias,name,country\nSTF,Supremo Tribunal Federal,Brazil\nTSE,Tribunal Superior Eleitoral,Brazil\n",
             encoding="utf-8",
         )
 
@@ -51,6 +51,50 @@ class TestReadCsvArrow(TestCase):
 
     def test_falls_back_when_pyarrow_missing(self) -> None:
         """When pyarrow is unavailable the helper still returns a valid
-        DataFrame (using the default pandas backend)."""
-        frame = read_csv_arrow(self.path)
+        DataFrame (using the default pandas backend) and does NOT push a
+        ``dtype_backend="pyarrow"`` argument through to ``pandas.read_csv``."""
+
+        # Force the ImportError branch in ``read_csv_arrow`` by hiding
+        # ``pyarrow`` from ``sys.modules``. Setting the entry to ``None``
+        # makes ``import pyarrow`` raise ``ImportError`` deterministically
+        # whether or not the package is installed in the environment.
+        captured: dict[str, dict] = {}
+        original_read_csv = pd.read_csv
+
+        def spy_read_csv(*args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            return original_read_csv(*args, **kwargs)
+
+        with patch.dict("sys.modules", {"pyarrow": None}):
+            with patch("pandas.read_csv", side_effect=spy_read_csv):
+                frame = read_csv_arrow(self.path)
         self.assertEqual(frame.shape, (2, 3))
+        # The helper must have skipped the pyarrow backend on this path.
+        self.assertNotIn("dtype_backend", captured["kwargs"])
+
+    def test_uses_pyarrow_backend_when_available(self) -> None:
+        """When pyarrow can be imported the helper forwards
+        ``dtype_backend="pyarrow"`` through to ``pandas.read_csv``."""
+
+        pa = pytest_importorskip_pyarrow()
+        if pa is None:
+            self.skipTest("pyarrow not installed in this environment")
+        captured: dict[str, dict] = {}
+        original_read_csv = pd.read_csv
+
+        def spy_read_csv(*args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            return original_read_csv(*args, **kwargs)
+
+        with patch("pandas.read_csv", side_effect=spy_read_csv):
+            read_csv_arrow(self.path)
+        self.assertEqual(captured["kwargs"].get("dtype_backend"), "pyarrow")
+
+
+def pytest_importorskip_pyarrow():
+    """Return the imported pyarrow module if it is installed, else ``None``."""
+    try:
+        import pyarrow  # noqa: F401 — availability probe only
+    except ImportError:
+        return None
+    return pyarrow

--- a/lexnlp/utils/tests/test_text_vectors.py
+++ b/lexnlp/utils/tests/test_text_vectors.py
@@ -111,3 +111,85 @@ class TestVectorizedSlice(TestCase):
     def test_empty_input(self):
         result = vectorized_slice([], 0, 1)
         self.assertEqual(result.shape, (0,))
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for PR change: StringDType and __array__ protocol
+# ---------------------------------------------------------------------------
+
+
+class TestAsStringArrayInternalBehavior(TestCase):
+    """Tests that exercise the PR-specific _as_string_array behaviour."""
+
+    def test_ndarray_input_uses_string_dtype(self):
+        """When given an ndarray, _as_string_array must return an array with
+        StringDType (not the legacy fixed-width np.str_)."""
+        from lexnlp.utils.text_vectors import _as_string_array
+
+        inp = np.array(["hello", "world"])
+        out = _as_string_array(inp)
+        self.assertIsInstance(out, np.ndarray)
+        # StringDType should compare equal to an instance of StringDType
+        self.assertIsInstance(out.dtype, np.dtypes.StringDType)
+
+    def test_list_input_uses_string_dtype(self):
+        """Plain list input must also yield a StringDType array."""
+        from lexnlp.utils.text_vectors import _as_string_array
+
+        out = _as_string_array(["a", "b", "c"])
+        self.assertIsInstance(out.dtype, np.dtypes.StringDType)
+
+    def test_object_with_array_protocol_is_accepted(self):
+        """Objects that implement __array__ (e.g. pandas Series) must not
+        be converted via list() — they should go through np.asarray()."""
+        from lexnlp.utils.text_vectors import _as_string_array
+
+        class FakeArrayLike:
+            def __array__(self, dtype=None, copy=None):
+                return np.array(["x", "y", "z"])
+
+        out = _as_string_array(FakeArrayLike())
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(list(out), ["x", "y", "z"])
+
+    def test_generator_input_materialised_correctly(self):
+        """Generator inputs (no __array__) must be materialised via list()."""
+        from lexnlp.utils.text_vectors import _as_string_array
+
+        gen = (c for c in ["p", "q", "r"])
+        out = _as_string_array(gen)
+        self.assertEqual(list(out), ["p", "q", "r"])
+
+
+class TestVectorizedLowerStringDType(TestCase):
+    """Verify vectorized_lower with the new StringDType backend."""
+
+    def test_lowercases_variable_length_unicode(self):
+        """StringDType handles variable-length strings without truncation."""
+        long_upper = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        short_upper = "Z"
+        result = vectorized_lower([long_upper, short_upper])
+        self.assertEqual(list(result), [long_upper.lower(), short_upper.lower()])
+
+    def test_accepts_numpy_string_array(self):
+        """An np.ndarray of strings (old np.str_ dtype) must be accepted."""
+        arr = np.array(["HELLO", "WORLD"], dtype=np.str_)
+        result = vectorized_lower(arr)
+        self.assertEqual(list(result), ["hello", "world"])
+
+
+class TestVectorizedStripStringDType(TestCase):
+    def test_strips_unicode_whitespace(self):
+        result = vectorized_strip(["\u3000foo\u3000", "bar"])
+        # \u3000 is an ideographic space — strip should handle it
+        # Result may or may not strip non-ASCII whitespace depending on
+        # the NumPy version; just verify no crash and correct length.
+        self.assertEqual(len(result), 2)
+
+    def test_mixed_length_strings(self):
+        """Strings with very different lengths must all be stripped correctly."""
+        data = ["  a  ", "  " + "x" * 100 + "  ", "  b  "]
+        result = vectorized_strip(data)
+        self.assertEqual(result[0], "a")
+        self.assertEqual(result[1], "x" * 100)
+        self.assertEqual(result[2], "b")

--- a/lexnlp/utils/tests/test_text_vectors.py
+++ b/lexnlp/utils/tests/test_text_vectors.py
@@ -130,14 +130,18 @@ class TestAsStringArrayInternalBehavior(TestCase):
         out = _as_string_array(inp)
         self.assertIsInstance(out, np.ndarray)
         # StringDType should compare equal to an instance of StringDType
-        self.assertIsInstance(out.dtype, np.dtypes.StringDType)
+        dtype = out.dtype
+        self.assertEqual(dtype.__class__.__name__, "StringDType")
+        self.assertTrue("numpy" in dtype.__class__.__module__)
 
     def test_list_input_uses_string_dtype(self):
         """Plain list input must also yield a StringDType array."""
         from lexnlp.utils.text_vectors import _as_string_array
 
         out = _as_string_array(["a", "b", "c"])
-        self.assertIsInstance(out.dtype, np.dtypes.StringDType)
+        dtype = out.dtype
+        self.assertEqual(dtype.__class__.__name__, "StringDType")
+        self.assertTrue("numpy" in dtype.__class__.__module__)
 
     def test_object_with_array_protocol_is_accepted(self):
         """Objects that implement __array__ (e.g. pandas Series) must not

--- a/lexnlp/utils/text_vectors.py
+++ b/lexnlp/utils/text_vectors.py
@@ -19,23 +19,28 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 from collections.abc import Iterable
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
 
 
-def _as_string_array(texts: Iterable[str]) -> NDArray[np.str_]:
-    if isinstance(texts, np.ndarray):
-        return texts.astype(np.str_, copy=False)
-    return np.asarray(list(texts), dtype=np.str_)
+def _as_string_array(texts: Iterable[str]) -> NDArray[Any]:
+    # ``StringDType`` is variable-length unicode (NumPy 2.0+) and avoids
+    # the truncation/oversizing that fixed-width ``np.str_`` causes when
+    # the inputs vary in length. Materialise non-array inputs once via
+    # ``list(...)`` only when there is no underlying array buffer.
+    if isinstance(texts, np.ndarray) or hasattr(texts, "__array__"):
+        return np.asarray(texts, dtype=np.dtypes.StringDType())
+    return np.asarray(list(texts), dtype=np.dtypes.StringDType())
 
 
-def vectorized_lower(texts: Iterable[str]) -> NDArray[np.str_]:
+def vectorized_lower(texts: Iterable[str]) -> NDArray[Any]:
     """Return ``texts`` lowercased via the NumPy 2.3 SIMD string kernel."""
     return np.strings.lower(_as_string_array(texts))
 
 
-def vectorized_strip(texts: Iterable[str]) -> NDArray[np.str_]:
+def vectorized_strip(texts: Iterable[str]) -> NDArray[Any]:
     """Strip surrounding whitespace from every element of ``texts``."""
     return np.strings.strip(_as_string_array(texts))
 
@@ -50,7 +55,7 @@ def vectorized_substring_count(texts: Iterable[str], substring: str) -> NDArray[
     return np.strings.count(_as_string_array(texts), substring)
 
 
-def vectorized_slice(texts: Iterable[str], start: int, stop: int) -> NDArray[np.str_]:
+def vectorized_slice(texts: Iterable[str], start: int, stop: int) -> NDArray[Any]:
     """Return the ``[start:stop]`` slice of every element of ``texts``.
 
     ``stop`` past the end of any individual element is handled the same


### PR DESCRIPTION
This PR addresses several bugs, improves test coverage, and enhances code quality across the lexnlp codebase.

## Summary
Multiple bug fixes and improvements including:
- Corrected conditional logic in citation and SSN annotations
- Fixed joblib pickle loading to handle uncompressed files
- Improved performance of citation variation lookups
- Enhanced test coverage and assertions
- Better error handling and validation
- Code cleanup and modernization

## Key Changes

**Bug Fixes:**
- Fixed `citation_annotation.py` to check `self.court` and `self.source` instead of `self.reporter` twice when populating dictionary values
- Fixed `ssn_annotation.py` to properly handle `None` values in `get_cite_value_parts()` by coercing to empty string
- Fixed `model_io.py` joblib fallback to handle uncompressed pickle files (`compress=0`) that don't start with zlib framing byte
- Fixed `cosine_similarity()` to validate that inputs are 1-D vectors before processing

**Performance Improvements:**
- Replaced O(n) per-call scan in `citation_variations.py` with O(1) hash lookup using a cached normalized variation index
- Changed `lookup_country()` and `fuzzy_country()` from unbounded `@cache` to `@lru_cache` with reasonable size limits (4096 and 2048 respectively)

**Validation & Error Handling:**
- Added validation in `fuzzy_country()` to reject non-positive `max_results` values with clear error messages
- Improved `_load_skops()` to skip expensive type scanning when `trusted=False`
- Enhanced error messages and exception handling in model loading

**Test Coverage:**
- Added comprehensive tests for pyarrow backend detection in CSV reading
- Added regression test for uncompressed joblib pickle files
- Added tests for skops trusted type handling and extra_trusted parameter flow
- Added tests for model card tag rendering and metric precision preservation
- Added tests for cosine similarity with 2-D inputs
- Added tests for country lookup validation
- Added test for public API re-export of `spawn_child_generators`

**Code Quality:**
- Improved type annotations in `text_vectors.py` to use NumPy 2.0+ `StringDType()` for variable-length strings
- Added clarifying comments explaining fallback logic and type handling
- Refactored test helpers to reduce duplication (e.g., `_fake_hub_module()`)
- Updated pre-commit configuration documentation
- Fixed typo in MODERNIZATION_ROADMAP.md (unicode capitalization)

**API Changes:**
- Added `adaptive_max_workers` to `__all__` export in `async_extract.py`

https://claude.ai/code/session_016XHaux4LBRQ9KzsyGH9Nyf

## Summary by Sourcery

Fix multiple small bugs and tighten validation while improving performance, NumPy/pyarrow integration, and public API clarity across extraction, ML, and utility modules.

Bug Fixes:
- Correct citation and SSN annotation dictionary/tag generation to use the appropriate fields and avoid propagating None values.
- Ensure legacy model loading correctly falls back to joblib for uncompressed pickle files and only re-raises when both pickle and joblib fail.
- Tighten skops trusted loading to raise clear ValueError messages for untrusted types and avoid unnecessary type scanning when trust checks are disabled.
- Validate cosine_similarity inputs as 1-D vectors and raise informative errors for invalid shapes.
- Enforce positive max_results values in fuzzy_country to prevent invalid fuzzy-matching calls.

Enhancements:
- Speed up citation variation lookups by introducing a cached normalized index for whitespace-insensitive matching.
- Modernize text vector utilities to use NumPy 2.x StringDType-based arrays for safer, variable-length Unicode handling.
- Clarify Hub mirror error messages and centralize test doubles for huggingface_hub, improving maintainability.
- Preserve metric precision and correctly render all tags in model card generation while documenting type-intent in annotations and caching helpers.
- Export adaptive_max_workers from the batch async module to make it part of the documented public API surface.

CI:
- Pin CI dependency installation to use uv sync --frozen for reproducible, lockfile-respecting environments.

Documentation:
- Update modernization roadmap wording and capitalization for Unicode and NumPy references, and clarify roadmap items describing model cards and Unicode-aware features.
- Improve pre-commit usage documentation to recommend invoking via uvx and explain the rationale for that workflow.

Tests:
- Add coverage for pyarrow-backed CSV reading to assert correct backend selection and argument forwarding when pyarrow is present or absent.
- Extend model_io tests for legacy joblib pickle handling, skops trust gating behaviour, and skipping untrusted-type scans when not in trusted mode.
- Add model card tests to verify tag rendering, metric precision preservation, and metadata defaults such as empty tags tuples and dataclass immutability.
- Strengthen cosine_similarity, country fuzzy matching, sklearn config, hub catalog, text batch RNG, and public API re-export tests to guard against regressions.