### PR TITLE
Address PR21/22/23 review comments and add DE/ES identifiers

### DIFF
--- a/lexnlp/extract/common/tests/test_countries.py
+++ b/lexnlp/extract/common/tests/test_countries.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 __author__ = "ContraxSuite, LLC; LexPredict, LLC"
 __copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
 __license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
@@ -139,13 +141,13 @@ class TestFuzzyCountryMaxResultsBoundary:
         import pytest
 
         with pytest.raises(TypeError, match="max_results must be an int"):
-            fuzzy_country("United", max_results=1.5)  # type: ignore[arg-type]
+            fuzzy_country("United", max_results=cast(Any, 1.5))
         with pytest.raises(TypeError, match="max_results must be an int"):
-            fuzzy_country("United", max_results="1")  # type: ignore[arg-type]
+            fuzzy_country("United", max_results=cast(Any, "1"))
         with pytest.raises(TypeError, match="max_results must be an int"):
             # ``bool`` is a subclass of ``int``; reject it explicitly so callers
             # don't accidentally pass ``True`` and silently slice to 1.
-            fuzzy_country("United", max_results=True)  # type: ignore[arg-type]
+            fuzzy_country("United", max_results=cast(Any, True))
 
     def test_returns_tuple_not_list(self) -> None:
         """Return type must be tuple, not list, to satisfy the type signature."""

--- a/lexnlp/extract/common/tests/test_countries.py
+++ b/lexnlp/extract/common/tests/test_countries.py
@@ -140,13 +140,16 @@ class TestFuzzyCountryMaxResultsBoundary:
         """Non-int values for max_results must raise TypeError, not silently slice."""
         import pytest
 
+        # cast(Any, ...) bypasses the static type checker so we can pass a
+        # non-int and assert the runtime ``TypeError`` is raised.
         with pytest.raises(TypeError, match="max_results must be an int"):
             fuzzy_country("United", max_results=cast(Any, 1.5))
         with pytest.raises(TypeError, match="max_results must be an int"):
             fuzzy_country("United", max_results=cast(Any, "1"))
         with pytest.raises(TypeError, match="max_results must be an int"):
-            # ``bool`` is a subclass of ``int``; reject it explicitly so callers
-            # don't accidentally pass ``True`` and silently slice to 1.
+            # ``bool`` is a subclass of ``int``; cast(Any, ...) lets us pass
+            # ``True`` past the type checker so callers don't accidentally
+            # silently slice to 1.
             fuzzy_country("United", max_results=cast(Any, True))
 
     def test_returns_tuple_not_list(self) -> None:

--- a/lexnlp/extract/de/__init__.py
+++ b/lexnlp/extract/de/__init__.py
@@ -1,6 +1,32 @@
+"""German (de) extraction support for LexNLP.
+
+Surfaces the German identifier extractors (Steuer-IdNr, USt-IdNr,
+Handelsregisternummer) ported from :mod:`lexnlp.extract.pt.identifiers`.
+The existing per-feature extractors (``amounts``, ``citations``,
+``courts``, ``dates``, ``definitions``, …) remain importable directly
+from their submodules.
+"""
+
 __author__ = "ContraxSuite, LLC; LexPredict, LLC"
 __copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
 __license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
 __version__ = "2.3.0"
 __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
+
+
+from lexnlp.extract.de.identifiers import (
+    DeIdentifierMatch,
+    get_hrb_annotations,
+    get_identifier_annotations,
+    get_steuer_idnr_annotations,
+    get_ust_idnr_annotations,
+)
+
+__all__ = [
+    "DeIdentifierMatch",
+    "get_hrb_annotations",
+    "get_identifier_annotations",
+    "get_steuer_idnr_annotations",
+    "get_ust_idnr_annotations",
+]

--- a/lexnlp/extract/de/identifiers.py
+++ b/lexnlp/extract/de/identifiers.py
@@ -97,21 +97,23 @@ def _digits(value: str) -> str:
 def _steuer_idnr_is_valid(digits: str) -> bool:
     """ISO/IEC 7064 ``MOD 11, 10`` check on a 10-digit body.
 
-    Per § 139b AO the Steuer-IdNr also requires that one digit appears
-    exactly twice or three times (in the new "Konsolidierte Variante");
-    we keep that runtime invariant in addition to the checksum to weed
-    out trivially-incorrect numbers.
+    Per § 139b AO the Steuer-IdNr also requires that exactly one digit
+    appears either twice or three times (Konsolidierte Variante, 2016)
+    and all other digits appear at most once; we keep that runtime
+    invariant in addition to the checksum to weed out trivially-incorrect
+    numbers. The Bundeszentralamt für Steuern also forbids a leading
+    zero, so we reject those up front.
     """
-    if len(digits) != 11 or digits == digits[0] * 11:
+    if len(digits) != 11 or digits[0] == "0" or digits == digits[0] * 11:
         return False
     body, check = digits[:10], int(digits[10])
 
-    # Repeat-digit invariant per Bundeszentralamt für Steuern. In the
-    # legacy variant exactly one digit appears twice, all others once.
-    # Since 2016 (KonsiNr) one digit may appear twice and a *different*
-    # digit may appear three times. Reject the rest.
+    # Repeat-digit invariant per Bundeszentralamt für Steuern. Exactly
+    # one digit in the 10-digit body appears twice (legacy variant) or
+    # three times (new variant since 2016); every other digit appears
+    # exactly once. Reject anything else.
     counts = sorted([body.count(c) for c in set(body)], reverse=True)
-    if counts not in ([2, 1, 1, 1, 1, 1, 1, 1, 1], [3, 2, 1, 1, 1, 1, 1]):
+    if counts not in ([2, 1, 1, 1, 1, 1, 1, 1, 1], [3, 1, 1, 1, 1, 1, 1, 1]):
         return False
 
     product = 10

--- a/lexnlp/extract/de/identifiers.py
+++ b/lexnlp/extract/de/identifiers.py
@@ -1,0 +1,208 @@
+"""German identifier extraction (Steuer-IdNr, USt-IdNr, HRB).
+
+Mirrors :mod:`lexnlp.extract.pt.identifiers`. The Steuer-IdNr and the
+USt-IdNr ship with check-digit algorithms (ISO/IEC 7064 ``MOD 11,10`` and
+``MOD 11`` respectively), so those extractors validate matches before
+emitting them. The Handelsregisternummer (``HRB`` / ``HRA``) does not
+expose a checksum and is therefore returned as a regex-only candidate.
+
+- ``get_steuer_idnr_annotations`` — Steuerliche Identifikationsnummer
+  ("Steuer-ID" / "IdNr"): 11 digits, ISO 7064 MOD 11,10 check on the
+  first ten, last digit is the check digit.
+- ``get_ust_idnr_annotations`` — Umsatzsteuer-Identifikationsnummer:
+  ``DE`` prefix + 9 digits, MOD 11 weighted check on the first eight.
+- ``get_hrb_annotations`` — Handelsregisternummer (``HRB`` Abteilung B,
+  ``HRA`` Abteilung A) — regex-only.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Generator
+from dataclasses import dataclass
+
+import regex as re
+
+# Steuer-IdNr surface: 11 digits, optional ``XX XXX XXX XXX``-style
+# whitespace separators tolerated.
+_STEUER_IDNR_RE = re.compile(
+    r"(?<!\d)"
+    r"(?P<idnr>\d{2}[\s.]?\d{3}[\s.]?\d{3}[\s.]?\d{3})"
+    r"(?!\d)"
+)
+
+# USt-IdNr surface: ``DE`` + 9 digits, optional separators.
+_UST_IDNR_RE = re.compile(
+    r"(?<!\w)"
+    r"(?:USt-IdNr\.?|UStID|VAT-?No\.?)?\s*"
+    r"(?P<ust>DE\s*\d{3}[\s.]?\d{3}[\s.]?\d{3})"
+    r"(?!\d)",
+    re.IGNORECASE,
+)
+
+# HRB / HRA: ``HRB 12345`` (Berlin) / ``HRA 99999`` (with optional court
+# prefix, e.g. ``Amtsgericht München HRB 12345``).
+_HRB_RE = re.compile(
+    r"(?<!\w)"
+    r"(?P<kind>HR[AB])"
+    r"\s+(?P<number>\d{1,7})"
+    r"(?!\d)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(slots=True, frozen=True)
+class DeIdentifierMatch:
+    """A validated German document identifier.
+
+    Attributes:
+        kind: ``"steuer_idnr"``, ``"ust_idnr"``, ``"hrb"`` or ``"hra"``.
+        value: canonicalized identifier (digits-only, plus the ``DE`` /
+            ``HR{A,B}`` prefix where present).
+        surface: matched surface form.
+        coords: inclusive-start / exclusive-end character offsets.
+        locale: locale tag (defaults to ``"de"``).
+    """
+
+    kind: str
+    value: str
+    surface: str
+    coords: tuple[int, int]
+    locale: str = "de"
+
+    def to_dictionary(self) -> dict:
+        """Return a dict representation suitable for downstream consumers."""
+        return {
+            "record_type": self.kind,
+            "coords": self.coords,
+            "text": self.surface,
+            "value": self.value,
+            "locale": self.locale,
+        }
+
+
+# ---------- helpers ----------
+
+
+def _digits(value: str) -> str:
+    """Return only the decimal digits of *value*."""
+    return re.sub(r"\D", "", value)
+
+
+def _steuer_idnr_is_valid(digits: str) -> bool:
+    """ISO/IEC 7064 ``MOD 11, 10`` check on a 10-digit body.
+
+    Per § 139b AO the Steuer-IdNr also requires that one digit appears
+    exactly twice or three times (in the new "Konsolidierte Variante");
+    we keep that runtime invariant in addition to the checksum to weed
+    out trivially-incorrect numbers.
+    """
+    if len(digits) != 11 or digits == digits[0] * 11:
+        return False
+    body, check = digits[:10], int(digits[10])
+
+    # Repeat-digit invariant per Bundeszentralamt für Steuern. In the
+    # legacy variant exactly one digit appears twice, all others once.
+    # Since 2016 (KonsiNr) one digit may appear twice and a *different*
+    # digit may appear three times. Reject the rest.
+    counts = sorted([body.count(c) for c in set(body)], reverse=True)
+    if counts not in ([2, 1, 1, 1, 1, 1, 1, 1, 1], [3, 2, 1, 1, 1, 1, 1]):
+        return False
+
+    product = 10
+    for digit in body:
+        sum_mod = (int(digit) + product) % 10
+        if sum_mod == 0:
+            sum_mod = 10
+        product = (sum_mod * 2) % 11
+    expected = (11 - product) % 10
+    return expected == check
+
+
+def _ust_idnr_is_valid(digits: str) -> bool:
+    """``MOD 11, 10`` check used for VAT IDs in Germany.
+
+    See `Bundeszentralamt für Steuern documentation
+    <https://www.bzst.de>`_ for the algorithm spec.
+    """
+    if len(digits) != 9:
+        return False
+    product = 10
+    for digit in digits[:8]:
+        sum_mod = (int(digit) + product) % 10
+        if sum_mod == 0:
+            sum_mod = 10
+        product = (sum_mod * 2) % 11
+    expected = (11 - product) % 10
+    return expected == int(digits[8])
+
+
+# ---------- public API ----------
+
+
+def get_steuer_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
+    """Yield validated Steuer-IdNr matches found in *text*."""
+    for match in _STEUER_IDNR_RE.finditer(text):
+        digits = _digits(match.group("idnr"))
+        if _steuer_idnr_is_valid(digits):
+            yield DeIdentifierMatch(
+                kind="steuer_idnr",
+                value=digits,
+                surface=match.group("idnr"),
+                coords=match.span("idnr"),
+            )
+
+
+def get_ust_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
+    """Yield validated USt-IdNr matches found in *text*."""
+    for match in _UST_IDNR_RE.finditer(text):
+        ust = match.group("ust").upper().replace(" ", "").replace(".", "")
+        digits = ust[2:] if ust.startswith("DE") else ust
+        if _ust_idnr_is_valid(digits):
+            yield DeIdentifierMatch(
+                kind="ust_idnr",
+                value="DE" + digits,
+                surface=match.group("ust"),
+                coords=match.span("ust"),
+            )
+
+
+def get_hrb_annotations(text: str) -> Generator[DeIdentifierMatch]:
+    """Yield Handelsregisternummer (``HRB`` / ``HRA``) candidates.
+
+    No check-digit algorithm exists for the Handelsregister, so matches
+    are surface-level candidates rather than validated identifiers.
+    """
+    for match in _HRB_RE.finditer(text):
+        kind = match.group("kind").upper()  # HRA or HRB
+        canonical = f"{kind} {match.group('number')}"
+        yield DeIdentifierMatch(
+            kind=kind.lower(),  # "hra" / "hrb"
+            value=canonical,
+            surface=match.group(0),
+            coords=match.span(),
+        )
+
+
+def get_identifier_annotations(text: str) -> Generator[DeIdentifierMatch]:
+    """Yield every German identifier we know how to extract.
+
+    Order: Steuer-IdNr, USt-IdNr, then Handelsregister numbers.
+    """
+    yield from get_steuer_idnr_annotations(text)
+    yield from get_ust_idnr_annotations(text)
+    yield from get_hrb_annotations(text)
+
+
+__all__ = [
+    "DeIdentifierMatch",
+    "get_hrb_annotations",
+    "get_identifier_annotations",
+    "get_steuer_idnr_annotations",
+    "get_ust_idnr_annotations",
+]

--- a/lexnlp/extract/de/identifiers.py
+++ b/lexnlp/extract/de/identifiers.py
@@ -23,7 +23,7 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
-from collections.abc import Generator
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 import regex as re
@@ -147,7 +147,7 @@ def _ust_idnr_is_valid(digits: str) -> bool:
 # ---------- public API ----------
 
 
-def get_steuer_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
+def get_steuer_idnr_annotations(text: str) -> Iterator[DeIdentifierMatch]:
     """Yield validated Steuer-IdNr matches found in *text*."""
     for match in _STEUER_IDNR_RE.finditer(text):
         digits = _digits(match.group("idnr"))
@@ -160,11 +160,12 @@ def get_steuer_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
             )
 
 
-def get_ust_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
+def get_ust_idnr_annotations(text: str) -> Iterator[DeIdentifierMatch]:
     """Yield validated USt-IdNr matches found in *text*."""
     for match in _UST_IDNR_RE.finditer(text):
-        ust = match.group("ust").upper().replace(" ", "").replace(".", "")
-        digits = ust[2:] if ust.startswith("DE") else ust
+        # ``_digits`` collapses any \s (tabs, newlines) plus ``.`` so an ID
+        # split across a line break still validates correctly.
+        digits = _digits(match.group("ust"))
         if _ust_idnr_is_valid(digits):
             yield DeIdentifierMatch(
                 kind="ust_idnr",
@@ -174,7 +175,7 @@ def get_ust_idnr_annotations(text: str) -> Generator[DeIdentifierMatch]:
             )
 
 
-def get_hrb_annotations(text: str) -> Generator[DeIdentifierMatch]:
+def get_hrb_annotations(text: str) -> Iterator[DeIdentifierMatch]:
     """Yield Handelsregisternummer (``HRB`` / ``HRA``) candidates.
 
     No check-digit algorithm exists for the Handelsregister, so matches
@@ -191,7 +192,7 @@ def get_hrb_annotations(text: str) -> Generator[DeIdentifierMatch]:
         )
 
 
-def get_identifier_annotations(text: str) -> Generator[DeIdentifierMatch]:
+def get_identifier_annotations(text: str) -> Iterator[DeIdentifierMatch]:
     """Yield every German identifier we know how to extract.
 
     Order: Steuer-IdNr, USt-IdNr, then Handelsregister numbers.

--- a/lexnlp/extract/de/tests/test_identifiers.py
+++ b/lexnlp/extract/de/tests/test_identifiers.py
@@ -1,0 +1,125 @@
+"""Tests for :mod:`lexnlp.extract.de.identifiers`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.de.identifiers import (
+    DeIdentifierMatch,
+    _steuer_idnr_is_valid,
+    _ust_idnr_is_valid,
+    get_hrb_annotations,
+    get_identifier_annotations,
+    get_steuer_idnr_annotations,
+    get_ust_idnr_annotations,
+)
+
+# ``47036892816`` is a valid Steuer-IdNr published as a BZSt test vector
+# (digit ``8`` repeats once, ISO 7064 MOD 11,10 check digit is 6).
+VALID_IDNR = "47036892816"
+# ``DE136695976`` is the published USt-IdNr of the Bundesfinanzhof.
+VALID_UST = "DE136695976"
+
+
+class TestSteuerIdnrValidator(TestCase):
+    def test_valid_idnr(self):
+        self.assertTrue(_steuer_idnr_is_valid(VALID_IDNR))
+
+    def test_invalid_check_digit(self):
+        # Flip the check digit from 6 -> 5.
+        self.assertFalse(_steuer_idnr_is_valid(VALID_IDNR[:-1] + "5"))
+
+    def test_all_zeros_rejected(self):
+        self.assertFalse(_steuer_idnr_is_valid("00000000000"))
+
+    def test_wrong_length(self):
+        self.assertFalse(_steuer_idnr_is_valid("1234567890"))
+
+    def test_repeat_digit_invariant_violated(self):
+        # Three different digits repeating - violates the BZSt invariant.
+        # "1122334560" has 1, 2 and 3 each appearing twice.
+        self.assertFalse(_steuer_idnr_is_valid("11223345607"))
+
+
+class TestUstIdnrValidator(TestCase):
+    def test_valid_ust(self):
+        self.assertTrue(_ust_idnr_is_valid(VALID_UST[2:]))  # strip ``DE``
+
+    def test_invalid_check_digit(self):
+        digits = VALID_UST[2:]
+        bad = digits[:-1] + str((int(digits[-1]) + 1) % 10)
+        self.assertFalse(_ust_idnr_is_valid(bad))
+
+    def test_wrong_length(self):
+        self.assertFalse(_ust_idnr_is_valid("12345678"))
+
+
+class TestSteuerIdnrAnnotations(TestCase):
+    def test_extracts_idnr(self):
+        text = f"Meine Steueridentifikationsnummer ist {VALID_IDNR}."
+        results = list(get_steuer_idnr_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual(VALID_IDNR, results[0].value)
+        self.assertEqual("steuer_idnr", results[0].kind)
+        self.assertEqual("de", results[0].locale)
+
+    def test_skips_invalid_idnr(self):
+        text = "IdNr 12345678901 ist falsch."
+        self.assertEqual([], list(get_steuer_idnr_annotations(text)))
+
+
+class TestUstIdnrAnnotations(TestCase):
+    def test_extracts_ust(self):
+        text = f"USt-IdNr.: {VALID_UST}"
+        results = list(get_ust_idnr_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual(VALID_UST, results[0].value)
+        self.assertEqual("ust_idnr", results[0].kind)
+
+    def test_to_dictionary(self):
+        match = next(get_ust_idnr_annotations(f"VAT-No {VALID_UST}"))
+        d = match.to_dictionary()
+        self.assertEqual("ust_idnr", d["record_type"])
+        self.assertEqual(VALID_UST, d["value"])
+
+
+class TestHrbAnnotations(TestCase):
+    def test_extracts_hrb(self):
+        text = "Eingetragen im Handelsregister, HRB 12345 Berlin."
+        results = list(get_hrb_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual("hrb", results[0].kind)
+        self.assertEqual("HRB 12345", results[0].value)
+
+    def test_extracts_hra(self):
+        text = "HRA 99876 Amtsgericht München."
+        results = list(get_hrb_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual("hra", results[0].kind)
+        self.assertEqual("HRA 99876", results[0].value)
+
+
+class TestGetIdentifierAnnotations(TestCase):
+    def test_extracts_all_kinds(self):
+        text = (
+            f"Steuer-IdNr {VALID_IDNR}, USt-IdNr {VALID_UST}, HRB 12345."
+        )
+        results = list(get_identifier_annotations(text))
+        kinds = sorted(r.kind for r in results)
+        self.assertEqual(["hrb", "steuer_idnr", "ust_idnr"], kinds)
+
+    def test_empty_text_yields_nothing(self):
+        self.assertEqual([], list(get_identifier_annotations("")))
+
+    def test_dataclass_is_frozen(self):
+        m = DeIdentifierMatch(
+            kind="ust_idnr", value=VALID_UST, surface=VALID_UST, coords=(0, 11)
+        )
+        with self.assertRaises(Exception):
+            setattr(m, "value", "DE000000000")

--- a/lexnlp/extract/de/tests/test_identifiers.py
+++ b/lexnlp/extract/de/tests/test_identifiers.py
@@ -46,6 +46,10 @@ class TestSteuerIdnrValidator(TestCase):
         # "1122334560" has 1, 2 and 3 each appearing twice.
         self.assertFalse(_steuer_idnr_is_valid("11223345607"))
 
+    def test_leading_zero_rejected(self):
+        # BZSt rule: the Steuer-IdNr cannot start with a zero.
+        self.assertFalse(_steuer_idnr_is_valid("0" + VALID_IDNR[1:]))
+
 
 class TestUstIdnrValidator(TestCase):
     def test_valid_ust(self):

--- a/lexnlp/extract/de/tests/test_identifiers.py
+++ b/lexnlp/extract/de/tests/test_identifiers.py
@@ -8,6 +8,7 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
+import dataclasses
 from unittest import TestCase
 
 from lexnlp.extract.de.identifiers import (
@@ -125,5 +126,23 @@ class TestGetIdentifierAnnotations(TestCase):
         m = DeIdentifierMatch(
             kind="ust_idnr", value=VALID_UST, surface=VALID_UST, coords=(0, 11)
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(dataclasses.FrozenInstanceError):
             setattr(m, "value", "DE000000000")
+
+
+class TestDeIdentifiersPackageReexports(TestCase):
+    """Lock the public surface of ``lexnlp.extract.de`` against drift."""
+
+    def test_reexports_are_identical_objects(self):
+        from lexnlp.extract import de as de_pkg
+        from lexnlp.extract.de import identifiers as identifiers_mod
+
+        for name in (
+            "DeIdentifierMatch",
+            "get_hrb_annotations",
+            "get_identifier_annotations",
+            "get_steuer_idnr_annotations",
+            "get_ust_idnr_annotations",
+        ):
+            self.assertIs(getattr(de_pkg, name), getattr(identifiers_mod, name))
+            self.assertIn(name, de_pkg.__all__)

--- a/lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py
+++ b/lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py
@@ -80,7 +80,11 @@ def test_pipeline_round_trips_via_skops(
 
     # Redirect the catalog to a writable temp dir so we don't touch the user's
     # ``~/.lexnlp/`` cache during tests.
+    original_catalog = catalog_mod.CATALOG
+    original_runtime_catalog = getattr(runtime_model, "CATALOG", None)
     catalog_mod.CATALOG = tmp_path
+    # type: ignore[attr-defined] - runtime_model.CATALOG is set dynamically and may not be
+    # declared in stubs; the test writes/restores it explicitly.
     runtime_model.CATALOG = tmp_path  # type: ignore[attr-defined]
     try:
         destination, wrote = write_pipeline_to_catalog(
@@ -89,8 +93,9 @@ def test_pipeline_round_trips_via_skops(
             force=True,
         )
     finally:
-        # Restore by reloading the module-level CATALOG resolution.
-        catalog_mod.CATALOG = catalog_mod._resolve_catalog_dir()
+        catalog_mod.CATALOG = original_catalog
+        if original_runtime_catalog is not None:
+            runtime_model.CATALOG = original_runtime_catalog
 
     assert wrote is True
     assert destination.exists()

--- a/lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py
+++ b/lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py
@@ -80,12 +80,11 @@ def test_pipeline_round_trips_via_skops(
 
     # Redirect the catalog to a writable temp dir so we don't touch the user's
     # ``~/.lexnlp/`` cache during tests.
+    _MISSING = object()  # sentinel so we can distinguish absent vs None
     original_catalog = catalog_mod.CATALOG
-    original_runtime_catalog = getattr(runtime_model, "CATALOG", None)
+    original_runtime_catalog = getattr(runtime_model, "CATALOG", _MISSING)
     catalog_mod.CATALOG = tmp_path
-    # type: ignore[attr-defined] - runtime_model.CATALOG is set dynamically and may not be
-    # declared in stubs; the test writes/restores it explicitly.
-    runtime_model.CATALOG = tmp_path  # type: ignore[attr-defined]
+    runtime_model.CATALOG = tmp_path  # type: ignore[attr-defined] - runtime_model.CATALOG is set dynamically and may not be declared in stubs
     try:
         destination, wrote = write_pipeline_to_catalog(
             pipeline=pipeline,
@@ -94,7 +93,9 @@ def test_pipeline_round_trips_via_skops(
         )
     finally:
         catalog_mod.CATALOG = original_catalog
-        if original_runtime_catalog is not None:
+        if original_runtime_catalog is _MISSING:
+            delattr(runtime_model, "CATALOG")
+        else:
             runtime_model.CATALOG = original_runtime_catalog
 
     assert wrote is True

--- a/lexnlp/extract/es/__init__.py
+++ b/lexnlp/extract/es/__init__.py
@@ -22,6 +22,12 @@ from lexnlp.extract.es.identifiers import (
     get_nie_annotations,
     get_nif_annotations,
 )
+from lexnlp.extract.es.regulations import (
+    get_regulation_annotation_list,
+    get_regulation_annotations,
+    get_regulation_list,
+    get_regulations,
+)
 
 __all__ = [
     "EsIdentifierMatch",
@@ -30,4 +36,8 @@ __all__ = [
     "get_identifier_annotations",
     "get_nie_annotations",
     "get_nif_annotations",
+    "get_regulation_annotation_list",
+    "get_regulation_annotations",
+    "get_regulation_list",
+    "get_regulations",
 ]

--- a/lexnlp/extract/es/__init__.py
+++ b/lexnlp/extract/es/__init__.py
@@ -1,6 +1,33 @@
+"""Spanish (es) extraction support for LexNLP.
+
+Mirrors the existing locale modules (``lexnlp.extract.de`` /
+``lexnlp.extract.pt``). Includes ``identifiers`` (DNI / NIE / NIF / CIF
+extractors with check-letter validation) ported from the Portuguese
+``lexnlp.extract.pt.identifiers`` design.
+"""
+
 __author__ = "ContraxSuite, LLC; LexPredict, LLC"
 __copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
 __license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
 __version__ = "2.3.0"
 __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
+
+
+from lexnlp.extract.es.identifiers import (
+    EsIdentifierMatch,
+    get_cif_annotations,
+    get_dni_annotations,
+    get_identifier_annotations,
+    get_nie_annotations,
+    get_nif_annotations,
+)
+
+__all__ = [
+    "EsIdentifierMatch",
+    "get_cif_annotations",
+    "get_dni_annotations",
+    "get_identifier_annotations",
+    "get_nie_annotations",
+    "get_nif_annotations",
+]

--- a/lexnlp/extract/es/identifiers.py
+++ b/lexnlp/extract/es/identifiers.py
@@ -1,0 +1,231 @@
+"""Spanish identifier extraction (DNI, NIE, NIF, CIF).
+
+This module mirrors :mod:`lexnlp.extract.pt.identifiers`. Each extractor
+validates its identifier with the official check-letter / check-digit
+algorithm so only well-formed numbers are emitted, keeping false
+positives low when the extractors run over noisy OCR.
+
+- ``get_dni_annotations`` — Documento Nacional de Identidad (8 digits +
+  letter; checksum based on ``digits % 23``).
+- ``get_nie_annotations`` — Número de Identidad de Extranjero (``[XYZ]`` +
+  7 digits + letter; the leading letter is mapped to ``0/1/2`` before
+  applying the DNI checksum).
+- ``get_nif_annotations`` — alias for natural-person tax identifier;
+  individuals' NIF is the DNI itself, foreigners' NIF is the NIE.
+- ``get_cif_annotations`` — legacy Código de Identificación Fiscal for
+  companies (letter + 7 digits + control char); now replaced by
+  company-NIF but still common in legacy contracts.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Generator
+from dataclasses import dataclass
+
+import regex as re
+
+# DNI surface: 8 digits followed by 1 letter (allowing optional separators).
+_DNI_RE = re.compile(
+    r"(?<![\w-])"
+    r"(?P<dni>\d{8}[\s-]?[A-HJ-NP-TV-Z])"
+    r"(?![\w-])",
+    re.IGNORECASE,
+)
+
+# NIE surface: X/Y/Z, optional dash, 7 digits, optional dash, 1 letter.
+_NIE_RE = re.compile(
+    r"(?<![\w-])"
+    r"(?P<nie>[XYZxyz][\s-]?\d{7}[\s-]?[A-HJ-NP-TV-Z])"
+    r"(?![\w-])",
+    re.IGNORECASE,
+)
+
+# CIF surface: leading control letter + 7 digits + check digit/letter.
+# Letter set per Real Decreto 1065/2007. Excludes letters reserved for the
+# DNI/NIE namespaces ("X", "Y", "Z", and "I", "O", "T" — which never appear
+# in legal CIFs).
+_CIF_RE = re.compile(
+    r"(?<![\w-])"
+    r"(?P<cif>[ABCDEFGHJKLMNPQRSUVW][\s-]?\d{7}[\s-]?[A-J0-9])"
+    r"(?![\w-])"
+)
+
+_DNI_CHECK_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE"
+_NIE_PREFIX_TO_DIGIT = {"X": "0", "Y": "1", "Z": "2"}
+
+
+@dataclass(slots=True, frozen=True)
+class EsIdentifierMatch:
+    """A validated Spanish document identifier.
+
+    Attributes:
+        kind: one of ``"dni"``, ``"nie"``, ``"nif"`` or ``"cif"``.
+        value: canonicalized identifier (digits + control letter, no
+            whitespace or dashes).
+        surface: original surface form as found in ``text``.
+        coords: inclusive-start / exclusive-end character offsets.
+        locale: locale tag (defaults to ``"es"``).
+    """
+
+    kind: str
+    value: str
+    surface: str
+    coords: tuple[int, int]
+    locale: str = "es"
+
+    def to_dictionary(self) -> dict:
+        """Return a dict representation suitable for downstream consumers."""
+        return {
+            "record_type": self.kind,
+            "coords": self.coords,
+            "text": self.surface,
+            "value": self.value,
+            "locale": self.locale,
+        }
+
+
+# ---------- helpers ----------
+
+
+def _strip_seps(value: str) -> str:
+    """Remove whitespace and dashes used as visual separators."""
+    return re.sub(r"[\s-]", "", value).upper()
+
+
+def _dni_letter_for(digits: str) -> str:
+    """Return the expected DNI check letter for an 8-digit numeric body."""
+    return _DNI_CHECK_LETTERS[int(digits) % 23]
+
+
+def _dni_is_valid(canonical: str) -> bool:
+    """Validate an 8-digit + letter DNI."""
+    if len(canonical) != 9 or not canonical[:8].isdigit():
+        return False
+    return _dni_letter_for(canonical[:8]) == canonical[8]
+
+
+def _nie_is_valid(canonical: str) -> bool:
+    """Validate a NIE: leading letter is folded to a digit, then DNI rule."""
+    if len(canonical) != 9:
+        return False
+    prefix = canonical[0]
+    if prefix not in _NIE_PREFIX_TO_DIGIT:
+        return False
+    body = _NIE_PREFIX_TO_DIGIT[prefix] + canonical[1:8]
+    if not body.isdigit():
+        return False
+    return _dni_letter_for(body) == canonical[8]
+
+
+def _cif_is_valid(canonical: str) -> bool:
+    """Validate a 9-character CIF using the official mod-10 algorithm."""
+    if len(canonical) != 9:
+        return False
+    head, body, control = canonical[0], canonical[1:8], canonical[8]
+    if not body.isdigit():
+        return False
+    digits = [int(c) for c in body]
+    odd_sum = 0
+    for d in digits[::2]:
+        doubled = d * 2
+        odd_sum += doubled // 10 + doubled % 10
+    even_sum = sum(digits[1::2])
+    total = odd_sum + even_sum
+    check_digit = (10 - (total % 10)) % 10
+    # Letters that *must* use the alpha control character.
+    if head in "PQRSNW":
+        return control == "JABCDEFGHI"[check_digit]
+    # Letters that *must* use the numeric control character.
+    if head in "ABEH":
+        return control.isdigit() and int(control) == check_digit
+    # Remaining letters accept either form.
+    if control.isdigit():
+        return int(control) == check_digit
+    return control == "JABCDEFGHI"[check_digit]
+
+
+# ---------- public API ----------
+
+
+def get_dni_annotations(text: str) -> Generator[EsIdentifierMatch]:
+    """Yield validated DNIs found in *text*."""
+    for match in _DNI_RE.finditer(text):
+        canonical = _strip_seps(match.group("dni"))
+        if _dni_is_valid(canonical):
+            yield EsIdentifierMatch(
+                kind="dni",
+                value=canonical,
+                surface=match.group("dni"),
+                coords=match.span("dni"),
+            )
+
+
+def get_nie_annotations(text: str) -> Generator[EsIdentifierMatch]:
+    """Yield validated NIEs found in *text*."""
+    for match in _NIE_RE.finditer(text):
+        canonical = _strip_seps(match.group("nie"))
+        if _nie_is_valid(canonical):
+            yield EsIdentifierMatch(
+                kind="nie",
+                value=canonical,
+                surface=match.group("nie"),
+                coords=match.span("nie"),
+            )
+
+
+def get_nif_annotations(text: str) -> Generator[EsIdentifierMatch]:
+    """Yield validated natural-person NIFs (DNIs ∪ NIEs)."""
+    for match in get_dni_annotations(text):
+        yield EsIdentifierMatch(
+            kind="nif",
+            value=match.value,
+            surface=match.surface,
+            coords=match.coords,
+        )
+    for match in get_nie_annotations(text):
+        yield EsIdentifierMatch(
+            kind="nif",
+            value=match.value,
+            surface=match.surface,
+            coords=match.coords,
+        )
+
+
+def get_cif_annotations(text: str) -> Generator[EsIdentifierMatch]:
+    """Yield validated legacy CIFs found in *text*."""
+    for match in _CIF_RE.finditer(text):
+        canonical = _strip_seps(match.group("cif"))
+        if _cif_is_valid(canonical):
+            yield EsIdentifierMatch(
+                kind="cif",
+                value=canonical,
+                surface=match.group("cif"),
+                coords=match.span("cif"),
+            )
+
+
+def get_identifier_annotations(text: str) -> Generator[EsIdentifierMatch]:
+    """Yield every Spanish identifier (DNI, NIE, CIF) found in *text*.
+
+    NIFs are not separately yielded because every DNI and every NIE is
+    already a NIF — emitting them again would produce duplicate spans.
+    """
+    yield from get_dni_annotations(text)
+    yield from get_nie_annotations(text)
+    yield from get_cif_annotations(text)
+
+
+__all__ = [
+    "EsIdentifierMatch",
+    "get_cif_annotations",
+    "get_dni_annotations",
+    "get_identifier_annotations",
+    "get_nie_annotations",
+    "get_nif_annotations",
+]

--- a/lexnlp/extract/es/identifiers.py
+++ b/lexnlp/extract/es/identifiers.py
@@ -25,7 +25,7 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
-from collections.abc import Generator
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 import regex as re
@@ -58,6 +58,9 @@ _CIF_RE = re.compile(
 
 _DNI_CHECK_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE"
 _NIE_PREFIX_TO_DIGIT = {"X": "0", "Y": "1", "Z": "2"}
+# Legal CIF leading letters per Real Decreto 1065/2007. Excludes "I", "O",
+# "T" (never assigned), and "X"/"Y"/"Z" (reserved for the NIE namespace).
+_CIF_HEAD_LETTERS = frozenset("ABCDEFGHJKLMNPQRSUVW")
 
 
 @dataclass(slots=True, frozen=True)
@@ -128,7 +131,7 @@ def _cif_is_valid(canonical: str) -> bool:
     if len(canonical) != 9:
         return False
     head, body, control = canonical[0], canonical[1:8], canonical[8]
-    if not body.isdigit():
+    if head not in _CIF_HEAD_LETTERS or not body.isdigit():
         return False
     digits = [int(c) for c in body]
     odd_sum = 0
@@ -153,7 +156,7 @@ def _cif_is_valid(canonical: str) -> bool:
 # ---------- public API ----------
 
 
-def get_dni_annotations(text: str) -> Generator[EsIdentifierMatch]:
+def get_dni_annotations(text: str) -> Iterator[EsIdentifierMatch]:
     """Yield validated DNIs found in *text*."""
     for match in _DNI_RE.finditer(text):
         canonical = _strip_seps(match.group("dni"))
@@ -166,7 +169,7 @@ def get_dni_annotations(text: str) -> Generator[EsIdentifierMatch]:
             )
 
 
-def get_nie_annotations(text: str) -> Generator[EsIdentifierMatch]:
+def get_nie_annotations(text: str) -> Iterator[EsIdentifierMatch]:
     """Yield validated NIEs found in *text*."""
     for match in _NIE_RE.finditer(text):
         canonical = _strip_seps(match.group("nie"))
@@ -179,7 +182,7 @@ def get_nie_annotations(text: str) -> Generator[EsIdentifierMatch]:
             )
 
 
-def get_nif_annotations(text: str) -> Generator[EsIdentifierMatch]:
+def get_nif_annotations(text: str) -> Iterator[EsIdentifierMatch]:
     """Yield validated natural-person NIFs (DNIs ∪ NIEs)."""
     for match in get_dni_annotations(text):
         yield EsIdentifierMatch(
@@ -197,7 +200,7 @@ def get_nif_annotations(text: str) -> Generator[EsIdentifierMatch]:
         )
 
 
-def get_cif_annotations(text: str) -> Generator[EsIdentifierMatch]:
+def get_cif_annotations(text: str) -> Iterator[EsIdentifierMatch]:
     """Yield validated legacy CIFs found in *text*."""
     for match in _CIF_RE.finditer(text):
         canonical = _strip_seps(match.group("cif"))
@@ -210,7 +213,7 @@ def get_cif_annotations(text: str) -> Generator[EsIdentifierMatch]:
             )
 
 
-def get_identifier_annotations(text: str) -> Generator[EsIdentifierMatch]:
+def get_identifier_annotations(text: str) -> Iterator[EsIdentifierMatch]:
     """Yield every Spanish identifier (DNI, NIE, CIF) found in *text*.
 
     NIFs are not separately yielded because every DNI and every NIE is

--- a/lexnlp/extract/es/identifiers.py
+++ b/lexnlp/extract/es/identifiers.py
@@ -134,12 +134,16 @@ def _cif_is_valid(canonical: str) -> bool:
     if head not in _CIF_HEAD_LETTERS or not body.isdigit():
         return False
     digits = [int(c) for c in body]
-    odd_sum = 0
+    # The CIF mod-10 algorithm walks the body using 1-indexed positions:
+    # odd-position digits (1st, 3rd, 5th, 7th — index 0/2/4/6) are doubled
+    # and their decimal digits summed; even-position digits (2nd, 4th, 6th
+    # — index 1/3/5) are summed as-is.
+    odd_pos_sum = 0
     for d in digits[::2]:
         doubled = d * 2
-        odd_sum += doubled // 10 + doubled % 10
-    even_sum = sum(digits[1::2])
-    total = odd_sum + even_sum
+        odd_pos_sum += doubled // 10 + doubled % 10
+    even_pos_sum = sum(digits[1::2])
+    total = odd_pos_sum + even_pos_sum
     check_digit = (10 - (total % 10)) % 10
     # Letters that *must* use the alpha control character.
     if head in "PQRSNW":

--- a/lexnlp/extract/es/regulations.py
+++ b/lexnlp/extract/es/regulations.py
@@ -165,17 +165,25 @@ class RegulationsParser:
             yield self._annotate(surface, match.span("full"), surface, locale)
 
     def _parse_article_references(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
-        seen_spans: set[tuple[int, int]] = set()
-        for match in ARTICLE_REFERENCE_RE.finditer(text):
-            surface = match.group("full")
-            span = match.span("full")
-            seen_spans.add(span)
-            yield self._annotate(surface, span, surface, locale)
+        # Materialise paragraph-leading spans first so we can suppress
+        # ``art. N`` matches that are nested inside an ``apartado N del art. N``
+        # span — otherwise the same article number would be emitted twice
+        # (once on its own and once as part of the paragraph-leading citation).
+        para_spans: list[tuple[int, int]] = []
+        para_matches: list[tuple[tuple[int, int], str]] = []
         for match in PARAGRAPH_LEADING_REFERENCE_RE.finditer(text):
             span = match.span("full")
-            if span in seen_spans:
+            para_spans.append(span)
+            para_matches.append((span, match.group("full")))
+
+        for match in ARTICLE_REFERENCE_RE.finditer(text):
+            span = match.span("full")
+            if any(ps <= span[0] and span[1] <= pe for ps, pe in para_spans):
                 continue
             surface = match.group("full")
+            yield self._annotate(surface, span, surface, locale)
+
+        for span, surface in para_matches:
             yield self._annotate(surface, span, surface, locale)
 
     def _parse_constitutional(self, text: str, locale: str) -> Generator[RegulationAnnotation]:

--- a/lexnlp/extract/es/regulations.py
+++ b/lexnlp/extract/es/regulations.py
@@ -1,3 +1,20 @@
+"""Regulation extraction for Spanish (es).
+
+Mirrors the architecture of :mod:`lexnlp.extract.pt.regulations`. Adds
+three concrete pattern families on top of the historical trigger-phrase
+matcher:
+
+- formal Spanish citations of state-level norms
+  (``Ley Orgánica 4/2015, de 30 de marzo``, ``Real Decreto 123/2020 de 16
+  de octubre``, ``Decreto-ley 1/2018``);
+- article references (``art. 5``, ``artículo 1.234`` and the
+  paragraph-leading variant ``apartado 2 del art. 14``);
+- constitutional references (``Constitución Española``, ``CE/78``).
+
+Trigger-phrase matches that fully contain a formal citation are
+suppressed so the canonical ``Ley X/YYYY`` span wins.
+"""
+
 __author__ = "ContraxSuite, LLC; LexPredict, LLC"
 __copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
 __license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
@@ -8,32 +25,83 @@ __email__ = "support@contraxsuite.com"
 
 import os
 from collections.abc import Generator
-
-# pylint: disable=unused-import
 from re import Pattern
 
-# pylint: enable=unused-import
 import regex as re
 from pandas import DataFrame, read_csv
 
 from lexnlp.extract.common.annotations.regulation_annotation import RegulationAnnotation
 from lexnlp.extract.common.base_path import lexnlp_base_path
 
+# --- formal Spanish citation patterns ----------------------------------------------------
+# Covers state, autonomic and EU-derived norms commonly cited in BOE / DOG /
+# DOGC / DOCM. Number formats: "4/2015" or "12345/2020"; optional "de DD de
+# <mes> de YYYY" trailing tail.
+_ACT_TYPE_RE = (
+    r"(?:"
+    r"Ley(?:\s+Orgánica|\s+Foral|\s+Ordinaria|\s+General)?|"
+    r"Real\s+Decreto(?:-Ley|\s+Legislativo)?|"
+    r"Decreto(?:-Ley|\s+Legislativo|\s+Foral)?|"
+    r"Reglamento|"
+    r"Orden(?:\s+Ministerial)?|"
+    r"Resolución|"
+    r"Instrucción|"
+    r"Circular|"
+    r"Directiva"
+    r")"
+)
+FORMAL_CITATION_RE = re.compile(
+    rf"(?P<full>{_ACT_TYPE_RE}\s+"
+    r"(?:n[.º°]\s*)?"
+    r"(?P<number>\d{1,5}(?:[/.-]\d{2,4})?)"
+    r"(?:\s*,?\s*de\s+\d{1,2}\s+de\s+\p{L}+(?:\s+de\s+\d{4})?)?)",
+    re.UNICODE | re.IGNORECASE,
+)
+
+# "art. 5", "artículo 1.234", "art. 5.2 LEC". Two patterns share group
+# names so callers can iterate ``itertools.chain(re1.finditer(t),
+# re2.finditer(t))`` and treat both as homogeneous matches.
+ARTICLE_REFERENCE_RE = re.compile(
+    r"(?P<full>(?:art\.?|artículo)\s*"
+    r"(?P<number>\d+(?:\.\d+)*[ºª]?(?:\s+bis|\s+ter|\s+quater)?)"
+    r"(?:\s*,?\s*(?:apartado|párrafo|inciso)\s*(?P<para>\d+[ºª]?))?)",
+    re.UNICODE | re.IGNORECASE,
+)
+# "apartado 2 del art. 14", "párrafo 3 del artículo 5", "inciso b del art. 12"
+PARAGRAPH_LEADING_REFERENCE_RE = re.compile(
+    r"(?P<full>"
+    r"(?:apartado\s*(?P<para>\d+[ºª]?)"
+    r"|párrafo\s*(?P<parrafo>\d+[ºª]?|primero|segundo|tercero|cuarto|quinto)"
+    r"|inciso\s*[\"']?(?P<inc>[a-z])[\"']?)"
+    r"\s+del\s+(?:art\.?|artículo)\s*"
+    r"(?P<number>\d+(?:\.\d+)*[ºª]?))",
+    re.UNICODE | re.IGNORECASE,
+)
+
+# "Constitución Española", "CE/78", "CE 1978"
+CONSTITUTIONAL_REF_RE = re.compile(
+    r"(?P<full>Constitución\s+Española(?:\s+de\s+\d{4})?|"
+    r"CE(?:[/\s]\d{2,4})?)",
+    re.UNICODE,
+)
+
 
 class RegulationsParser:
-    """
-    Parses Spanish regulations (acts, institutions and so on):
-    - "la emisión de instrumentos inscritos en el Registro Nacional de Valores, colocados"
-      boils down to 'Registro Nacional de Valores'
+    """Parses Spanish legal references.
 
-    - expects words like 'registro', 'comisión', 'comision', 'ley del'
-      that open the following phrase
+    ``parse()`` yields :class:`RegulationAnnotation` objects for:
+
+    1. Trigger-word phrases listed in
+       ``lexnlp/config/es/es_regulations.csv`` (backwards-compatible).
+    2. Formal Spanish act citations (``Ley Orgánica 4/2015``).
+    3. Article references (``art. 5``, ``apartado 2 del art. 14``).
+    4. Constitutional references (``Constitución Española``).
     """
 
-    def __init__(self, regulations_dataframe: DataFrame = None):
-        """
-        :param regulations_dataframe: a pandas dataframe with 2 columns: trigger: str, position: str
-        """
+    DEFAULT_COUNTRY = "Spain"
+
+    def __init__(self, regulations_dataframe: DataFrame | None = None):
+        """Initialise the parser, loading triggers from CSV when needed."""
         self.regulations_dataframe = regulations_dataframe
         self.start_triggers: list[str] = []
         self.reg_start_triggers: list[Pattern] = []
@@ -41,78 +109,139 @@ class RegulationsParser:
         self.setup_regexes()
 
     def setup_regexes(self) -> None:
-        """
-        Read *.csv content and build regexes out of this data
-        """
-        triggers_str = "|".join(self.start_triggers)
-        reg = re.compile(r"(?:(?<=[\s\b])|(?<=^))(%s)[^,\b;\.\n]+" % triggers_str, re.UNICODE | re.IGNORECASE)
-        self.reg_start_triggers.append(reg)
+        """Compile a single regex that matches any registered start trigger."""
+        if not self.start_triggers:
+            self.reg_start_triggers = []
+            return
+        triggers_ordered = sorted(self.start_triggers, key=len, reverse=True)
+        triggers_escaped = [re.escape(t) for t in triggers_ordered]
+        triggers_str = "|".join(triggers_escaped)
+        # Spanish acts also use thousand-separating dots ("1.234"). Allow a
+        # period only when followed by a digit so sentence-ending periods
+        # still terminate the match.
+        pattern = re.compile(
+            rf"(?:(?<=\s)|(?<=^))({triggers_str})(?:[^,;.\n]|\.(?=\d))+",
+            re.UNICODE | re.IGNORECASE,
+        )
+        self.reg_start_triggers = [pattern]
 
     def load_trigger_words(self) -> None:
-        """
-        Load records like ('ley del', 'start') - (trigger_word, position)
-        """
-        dtypes = {"trigger": str, "position": str}
+        """Populate ``start_triggers`` from CSV or injected DataFrame."""
         if self.regulations_dataframe is None:
             path = os.path.join(lexnlp_base_path, "lexnlp/config/es/es_regulations.csv")
-            self.regulations_dataframe = read_csv(path, encoding="utf-8", on_bad_lines="skip", converters=dtypes)
+            self.regulations_dataframe = read_csv(
+                path,
+                encoding="utf-8",
+                on_bad_lines="skip",
+                dtype={"trigger": str, "position": str},
+            )
         subset = self.regulations_dataframe[["trigger", "position"]]
         tuples = [tuple(x) for x in subset.values]
         self.start_triggers = [t[0] for t in tuples if t[1] == "start"]
 
-    def parse(self, text: str, locale: str = "es") -> Generator[RegulationAnnotation]:
-        """
-        Find annotations in text passed and return them as a list of objects
-        """
+    # --- extraction helpers --------------------------------------------
+
+    @staticmethod
+    def _annotate(
+        name: str, coords: tuple[int, int], surface: str, locale: str, country: str = "Spain"
+    ) -> RegulationAnnotation:
+        return RegulationAnnotation(
+            name=name,
+            coords=coords,
+            text=surface,
+            locale=locale,
+            country=country,
+        )
+
+    def _parse_trigger_phrases(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
         for reg in self.reg_start_triggers:
             for match in reg.finditer(text):
-                text = match.group()
-                coords = (match.start(), match.end())
-                annotation = RegulationAnnotation(
-                    name=text,
-                    coords=coords,
-                    text=text,
-                    locale=locale,
-                    country="Spain",
-                )
-                yield annotation
+                surface = match.group()
+                yield self._annotate(surface, match.span(), surface, locale)
+
+    def _parse_formal_citations(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+        for match in FORMAL_CITATION_RE.finditer(text):
+            surface = match.group("full")
+            yield self._annotate(surface, match.span("full"), surface, locale)
+
+    def _parse_article_references(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+        seen_spans: set[tuple[int, int]] = set()
+        for match in ARTICLE_REFERENCE_RE.finditer(text):
+            surface = match.group("full")
+            span = match.span("full")
+            seen_spans.add(span)
+            yield self._annotate(surface, span, surface, locale)
+        for match in PARAGRAPH_LEADING_REFERENCE_RE.finditer(text):
+            span = match.span("full")
+            if span in seen_spans:
+                continue
+            surface = match.group("full")
+            yield self._annotate(surface, span, surface, locale)
+
+    def _parse_constitutional(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+        for match in CONSTITUTIONAL_REF_RE.finditer(text):
+            surface = match.group("full")
+            yield self._annotate(
+                "Constitución Española",
+                match.span("full"),
+                surface,
+                locale,
+            )
+
+    # --- public API ----------------------------------------------------
+
+    def parse(self, text: str, locale: str = "es") -> Generator[RegulationAnnotation]:
+        """Yield all regulation annotations found in *text*.
+
+        Trigger-phrase matches whose span fully contains a formal citation
+        are dropped so the canonical "Ley X/YYYY" form wins.
+        """
+        formal: list[RegulationAnnotation] = list(self._parse_formal_citations(text, locale))
+        formal_spans = [(ann.coords[0], ann.coords[1]) for ann in formal]
+
+        for trigger in self._parse_trigger_phrases(text, locale):
+            t_start, t_end = trigger.coords
+            if any(t_start <= fs and fe <= t_end for fs, fe in formal_spans):
+                continue
+            yield trigger
+        yield from formal
+        yield from self._parse_article_references(text, locale)
+        yield from self._parse_constitutional(text, locale)
 
 
 parser = RegulationsParser()
 
 
 def get_regulation_annotations(text: str, language: str = "es") -> Generator[RegulationAnnotation]:
+    """Yield :class:`RegulationAnnotation` instances found in *text*."""
     yield from parser.parse(text, language)
 
 
 def get_regulation_annotation_list(text: str, language: str = "es") -> list[RegulationAnnotation]:
+    """Return all regulation annotations from *text* as a list."""
     return list(parser.parse(text, language))
 
 
 def get_regulations(text: str, language: str = "es") -> Generator[dict]:
-    """
-    Yield regulation annotations found in the input text as dictionaries.
-
-    Parameters:
-        text (str): Input text to scan for regulation mentions.
-        language (str): Language code used by the parser (default 'es').
-
-    Yields:
-        dict: Dictionary representation of each RegulationAnnotation (e.g., containing 'name', 'coords', 'text', 'locale', 'country').
-    """
+    """Yield regulation annotations as serialisable dictionaries."""
     for reg in parser.parse(text, language):
         yield reg.to_dictionary()
 
 
 def get_regulation_list(text: str, language: str | None = None) -> list[dict]:
-    """
-    Return a list of regulation annotations extracted from the given text.
-
-    Parameters:
-        text (str): Input text to search for regulation mentions.
-        language (str | None): Language code to use for parsing; when `None`, defaults to `'es'`.
-
-    Returns:
-        list[dict]: A list of dictionaries representing found regulation annotations.
-    """
+    """Return all regulation annotations as a list of dictionaries."""
     return list(get_regulations(text, language or "es"))
+
+
+__all__ = [
+    "ARTICLE_REFERENCE_RE",
+    "CONSTITUTIONAL_REF_RE",
+    "FORMAL_CITATION_RE",
+    "PARAGRAPH_LEADING_REFERENCE_RE",
+    "RegulationsParser",
+    "get_regulation_annotation_list",
+    "get_regulation_annotations",
+    "get_regulation_list",
+    "get_regulations",
+    "parser",
+]

--- a/lexnlp/extract/es/regulations.py
+++ b/lexnlp/extract/es/regulations.py
@@ -24,8 +24,7 @@ __email__ = "support@contraxsuite.com"
 
 
 import os
-from collections.abc import Generator
-from re import Pattern
+from collections.abc import Iterator
 
 import regex as re
 from pandas import DataFrame, read_csv
@@ -78,11 +77,13 @@ PARAGRAPH_LEADING_REFERENCE_RE = re.compile(
     re.UNICODE | re.IGNORECASE,
 )
 
-# "Constitución Española", "CE/78", "CE 1978"
+# "Constitución Española", "CE/78", "CE 1978" — case-insensitive and
+# word-bounded so ``constitución española`` / ``ce/78`` match while
+# embedded sequences like ``CECA`` or ``ICE`` do not.
 CONSTITUTIONAL_REF_RE = re.compile(
-    r"(?P<full>Constitución\s+Española(?:\s+de\s+\d{4})?|"
-    r"CE(?:[/\s]\d{2,4})?)",
-    re.UNICODE,
+    r"(?<!\w)(?P<full>Constitución\s+Española(?:\s+de\s+\d{4})?|"
+    r"CE(?:[/\s]\d{2,4})?)(?!\w)",
+    re.UNICODE | re.IGNORECASE,
 )
 
 
@@ -104,7 +105,7 @@ class RegulationsParser:
         """Initialise the parser, loading triggers from CSV when needed."""
         self.regulations_dataframe = regulations_dataframe
         self.start_triggers: list[str] = []
-        self.reg_start_triggers: list[Pattern] = []
+        self.reg_start_triggers: list[re.Pattern] = []
         self.load_trigger_words()
         self.setup_regexes()
 
@@ -153,18 +154,18 @@ class RegulationsParser:
             country=country,
         )
 
-    def _parse_trigger_phrases(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+    def _parse_trigger_phrases(self, text: str, locale: str) -> Iterator[RegulationAnnotation]:
         for reg in self.reg_start_triggers:
             for match in reg.finditer(text):
                 surface = match.group()
                 yield self._annotate(surface, match.span(), surface, locale)
 
-    def _parse_formal_citations(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+    def _parse_formal_citations(self, text: str, locale: str) -> Iterator[RegulationAnnotation]:
         for match in FORMAL_CITATION_RE.finditer(text):
             surface = match.group("full")
             yield self._annotate(surface, match.span("full"), surface, locale)
 
-    def _parse_article_references(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+    def _parse_article_references(self, text: str, locale: str) -> Iterator[RegulationAnnotation]:
         # Materialise paragraph-leading spans first so we can suppress
         # ``art. N`` matches that are nested inside an ``apartado N del art. N``
         # span — otherwise the same article number would be emitted twice
@@ -186,7 +187,7 @@ class RegulationsParser:
         for span, surface in para_matches:
             yield self._annotate(surface, span, surface, locale)
 
-    def _parse_constitutional(self, text: str, locale: str) -> Generator[RegulationAnnotation]:
+    def _parse_constitutional(self, text: str, locale: str) -> Iterator[RegulationAnnotation]:
         for match in CONSTITUTIONAL_REF_RE.finditer(text):
             surface = match.group("full")
             yield self._annotate(
@@ -198,7 +199,7 @@ class RegulationsParser:
 
     # --- public API ----------------------------------------------------
 
-    def parse(self, text: str, locale: str = "es") -> Generator[RegulationAnnotation]:
+    def parse(self, text: str, locale: str = "es") -> Iterator[RegulationAnnotation]:
         """Yield all regulation annotations found in *text*.
 
         Trigger-phrase matches whose span fully contains a formal citation
@@ -220,7 +221,7 @@ class RegulationsParser:
 parser = RegulationsParser()
 
 
-def get_regulation_annotations(text: str, language: str = "es") -> Generator[RegulationAnnotation]:
+def get_regulation_annotations(text: str, language: str = "es") -> Iterator[RegulationAnnotation]:
     """Yield :class:`RegulationAnnotation` instances found in *text*."""
     yield from parser.parse(text, language)
 
@@ -230,7 +231,7 @@ def get_regulation_annotation_list(text: str, language: str = "es") -> list[Regu
     return list(parser.parse(text, language))
 
 
-def get_regulations(text: str, language: str = "es") -> Generator[dict]:
+def get_regulations(text: str, language: str = "es") -> Iterator[dict]:
     """Yield regulation annotations as serialisable dictionaries."""
     for reg in parser.parse(text, language):
         yield reg.to_dictionary()

--- a/lexnlp/extract/es/tests/test_identifiers.py
+++ b/lexnlp/extract/es/tests/test_identifiers.py
@@ -1,0 +1,140 @@
+"""Tests for :mod:`lexnlp.extract.es.identifiers`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.es.identifiers import (
+    EsIdentifierMatch,
+    _cif_is_valid,
+    _dni_is_valid,
+    _nie_is_valid,
+    get_cif_annotations,
+    get_dni_annotations,
+    get_identifier_annotations,
+    get_nie_annotations,
+    get_nif_annotations,
+)
+
+
+class TestDniValidator(TestCase):
+    def test_valid_dni(self):
+        self.assertTrue(_dni_is_valid("12345678Z"))
+
+    def test_invalid_check_letter(self):
+        self.assertFalse(_dni_is_valid("12345678A"))
+
+    def test_invalid_length(self):
+        self.assertFalse(_dni_is_valid("1234567Z"))
+
+    def test_lowercase_letter_rejected(self):
+        # Canonical form is uppercase; the public extractors normalise
+        # before calling this validator.
+        self.assertFalse(_dni_is_valid("12345678z"))
+
+
+class TestNieValidator(TestCase):
+    def test_valid_x_prefix(self):
+        self.assertTrue(_nie_is_valid("X1234567L"))
+
+    def test_valid_y_prefix(self):
+        self.assertTrue(_nie_is_valid("Y1234567X"))
+
+    def test_invalid_prefix(self):
+        # ``A`` is not a valid NIE prefix.
+        self.assertFalse(_nie_is_valid("A1234567L"))
+
+    def test_invalid_check_letter(self):
+        self.assertFalse(_nie_is_valid("X1234567A"))
+
+
+class TestCifValidator(TestCase):
+    def test_valid_cif_alpha_control(self):
+        # ``A`` letter forces numeric control character.
+        self.assertTrue(_cif_is_valid("A12345674"))
+
+    def test_invalid_cif(self):
+        self.assertFalse(_cif_is_valid("A12345670"))
+
+    def test_invalid_letter(self):
+        # ``T`` is not a CIF leading letter.
+        self.assertFalse(_cif_is_valid("T12345674"))
+
+
+class TestGetDniAnnotations(TestCase):
+    def test_extracts_dni(self):
+        text = "El propietario presenta el DNI 12345678Z para el contrato."
+        results = list(get_dni_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual("12345678Z", results[0].value)
+        self.assertEqual("dni", results[0].kind)
+        self.assertEqual("es", results[0].locale)
+
+    def test_does_not_extract_invalid_dni(self):
+        text = "Este DNI 12345678A es inválido."
+        results = list(get_dni_annotations(text))
+        self.assertEqual([], results)
+
+    def test_to_dictionary(self):
+        text = "DNI: 12345678Z."
+        match = next(get_dni_annotations(text))
+        d = match.to_dictionary()
+        self.assertEqual("dni", d["record_type"])
+        self.assertEqual("12345678Z", d["value"])
+        self.assertEqual("es", d["locale"])
+
+
+class TestGetNieAnnotations(TestCase):
+    def test_extracts_nie(self):
+        text = "El residente extranjero presenta NIE X1234567L hoy."
+        results = list(get_nie_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual("X1234567L", results[0].value)
+        self.assertEqual("nie", results[0].kind)
+
+
+class TestGetCifAnnotations(TestCase):
+    def test_extracts_cif(self):
+        text = "La sociedad con CIF A12345674 firmó el acuerdo."
+        results = list(get_cif_annotations(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual("A12345674", results[0].value)
+        self.assertEqual("cif", results[0].kind)
+
+
+class TestGetNifAnnotations(TestCase):
+    def test_nif_includes_dni_and_nie(self):
+        text = "DNI 12345678Z y NIE X1234567L."
+        results = list(get_nif_annotations(text))
+        kinds = {r.kind for r in results}
+        self.assertEqual({"nif"}, kinds)
+        values = {r.value for r in results}
+        self.assertEqual({"12345678Z", "X1234567L"}, values)
+
+
+class TestGetIdentifierAnnotations(TestCase):
+    def test_extracts_all_kinds(self):
+        text = (
+            "El consumidor con DNI 12345678Z y la sociedad CIF A12345674. "
+            "El residente con NIE X1234567L también firma."
+        )
+        results = list(get_identifier_annotations(text))
+        kinds = sorted(r.kind for r in results)
+        self.assertEqual(["cif", "dni", "nie"], kinds)
+
+    def test_empty_text_yields_nothing(self):
+        self.assertEqual([], list(get_identifier_annotations("")))
+
+    def test_dataclass_is_frozen(self):
+        m = EsIdentifierMatch(
+            kind="dni", value="12345678Z", surface="12345678Z", coords=(0, 9)
+        )
+        with self.assertRaises(Exception):
+            # Frozen dataclass mutation must raise FrozenInstanceError.
+            setattr(m, "value", "00000000T")

--- a/lexnlp/extract/es/tests/test_identifiers.py
+++ b/lexnlp/extract/es/tests/test_identifiers.py
@@ -8,6 +8,7 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
+import dataclasses
 from unittest import TestCase
 
 from lexnlp.extract.es.identifiers import (
@@ -135,6 +136,24 @@ class TestGetIdentifierAnnotations(TestCase):
         m = EsIdentifierMatch(
             kind="dni", value="12345678Z", surface="12345678Z", coords=(0, 9)
         )
-        with self.assertRaises(Exception):
-            # Frozen dataclass mutation must raise FrozenInstanceError.
+        with self.assertRaises(dataclasses.FrozenInstanceError):
             setattr(m, "value", "00000000T")
+
+
+class TestEsIdentifiersPackageReexports(TestCase):
+    """Lock the public surface of ``lexnlp.extract.es`` against drift."""
+
+    def test_reexports_are_identical_objects(self):
+        from lexnlp.extract import es as es_pkg
+        from lexnlp.extract.es import identifiers as identifiers_mod
+
+        for name in (
+            "EsIdentifierMatch",
+            "get_cif_annotations",
+            "get_dni_annotations",
+            "get_identifier_annotations",
+            "get_nie_annotations",
+            "get_nif_annotations",
+        ):
+            self.assertIs(getattr(es_pkg, name), getattr(identifiers_mod, name))
+            self.assertIn(name, es_pkg.__all__)

--- a/lexnlp/extract/es/tests/test_regulations.py
+++ b/lexnlp/extract/es/tests/test_regulations.py
@@ -161,6 +161,16 @@ class TestRegulationsParserDataFrameInjection:
         assert len(matches) == 1
         assert matches[0].group("full") == "apartado 2 del art. 14"
 
+    def test_parser_suppresses_nested_article_inside_paragraph_leading(self):
+        """``apartado 2 del art. 14`` must NOT also yield a separate ``art. 14``."""
+        text = "Aplica el apartado 2 del art. 14 de la norma."
+        regs = list(parser.parse(text))
+        names = [r.name for r in regs]
+        assert "apartado 2 del art. 14" in names
+        # ``art. 14`` is nested inside the paragraph-leading span, so it must
+        # not be emitted on its own.
+        assert "art. 14" not in names
+
     def test_constitutional_reference(self):
         text = "Según la Constitución Española de 1978."
         matches = list(CONSTITUTIONAL_REF_RE.finditer(text))
@@ -180,9 +190,12 @@ class TestRegulationsParserDataFrameInjection:
             " los plazos se actualizan."
         )
         regs = list(parser.parse(text))
-        names = [r.name for r in regs]
-        # Formal citation must always appear:
-        assert any("Real Decreto 123/2020" in n for n in names)
+        # The trigger phrase ("ley de protección Real Decreto 123/2020 vigente")
+        # fully contains the formal citation, so it must be dropped — only the
+        # canonical "Real Decreto 123/2020" should survive.
+        assert len(regs) == 1
+        assert regs[0].name == "Real Decreto 123/2020"
+        assert regs[0].text == "Real Decreto 123/2020"
 
     def test_empty_dataframe_means_no_triggers_no_csv_load(self):
         """

--- a/lexnlp/extract/es/tests/test_regulations.py
+++ b/lexnlp/extract/es/tests/test_regulations.py
@@ -11,7 +11,16 @@ from unittest import TestCase
 import pandas as pd
 
 from lexnlp.extract.common.annotations.regulation_annotation import RegulationAnnotation
-from lexnlp.extract.es.regulations import RegulationsParser, get_regulation_annotations, get_regulations, parser
+from lexnlp.extract.es.regulations import (
+    ARTICLE_REFERENCE_RE,
+    CONSTITUTIONAL_REF_RE,
+    FORMAL_CITATION_RE,
+    PARAGRAPH_LEADING_REFERENCE_RE,
+    RegulationsParser,
+    get_regulation_annotations,
+    get_regulations,
+    parser,
+)
 from lexnlp.tests.typed_annotations_tests import TypedAnnotationsTester
 from lexnlp.tests.utility_for_testing import annotate_text, load_resource_document, save_test_document
 
@@ -125,6 +134,55 @@ class TestRegulationsParserDataFrameInjection:
         p = RegulationsParser(regulations_dataframe=custom_df)
         assert "ley del" in p.start_triggers
         assert "reglamento" not in p.start_triggers
+
+    def test_formal_citation_ley_organica(self):
+        """``Ley Orgánica 4/2015`` is captured by FORMAL_CITATION_RE."""
+        text = "Conforme a la Ley Orgánica 4/2015, de 30 de marzo, de protección."
+        matches = list(FORMAL_CITATION_RE.finditer(text))
+        assert len(matches) >= 1
+        assert "Ley Orgánica 4/2015" in matches[0].group("full")
+
+    def test_formal_citation_real_decreto(self):
+        """``Real Decreto 123/2020`` is captured."""
+        text = "El Real Decreto 123/2020 establece nuevos plazos."
+        matches = list(FORMAL_CITATION_RE.finditer(text))
+        assert len(matches) == 1
+        assert matches[0].group("number") == "123/2020"
+
+    def test_article_reference_simple(self):
+        text = "Vid. art. 5 de la norma."
+        matches = list(ARTICLE_REFERENCE_RE.finditer(text))
+        assert len(matches) == 1
+        assert matches[0].group("number") == "5"
+
+    def test_paragraph_leading_apartado(self):
+        text = "Aplica el apartado 2 del art. 14 de la ley."
+        matches = list(PARAGRAPH_LEADING_REFERENCE_RE.finditer(text))
+        assert len(matches) == 1
+        assert matches[0].group("full") == "apartado 2 del art. 14"
+
+    def test_constitutional_reference(self):
+        text = "Según la Constitución Española de 1978."
+        matches = list(CONSTITUTIONAL_REF_RE.finditer(text))
+        assert len(matches) >= 1
+
+    def test_parser_emits_constitutional_canonical_name(self):
+        text = "Vid. la Constitución Española."
+        regs = list(parser.parse(text))
+        cfs = [r for r in regs if r.name == "Constitución Española"]
+        assert len(cfs) == 1
+        assert cfs[0].country == "Spain"
+
+    def test_parser_dedupes_trigger_swallowing_formal_citation(self):
+        """A trigger phrase that engulfs a formal citation is suppressed."""
+        text = (
+            "Conforme a la ley de protección Real Decreto 123/2020 vigente,"
+            " los plazos se actualizan."
+        )
+        regs = list(parser.parse(text))
+        names = [r.name for r in regs]
+        # Formal citation must always appear:
+        assert any("Real Decreto 123/2020" in n for n in names)
 
     def test_empty_dataframe_means_no_triggers_no_csv_load(self):
         """

--- a/lexnlp/extract/ml/classifier/spacy_token_sequence_model.py
+++ b/lexnlp/extract/ml/classifier/spacy_token_sequence_model.py
@@ -8,10 +8,14 @@ __email__ = "support@contraxsuite.com"
 
 import os
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 import numpy
 
 from lexnlp.extract.ml.classifier.base_token_sequence_classifier_model import BaseTokenSequenceClassifierModel
+
+if TYPE_CHECKING:
+    from spacy.language import Language
 
 MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -31,7 +35,7 @@ def _resolve_spacy_model_name() -> str:
 
 
 @lru_cache(maxsize=4)
-def _load_spacy_pipeline(model_name: str | None = None):
+def _load_spacy_pipeline(model_name: str | None = None) -> "Language":
     """Return a cached spaCy ``Language`` pipeline.
 
     Raises ``ImportError`` (with an actionable message) if the optional
@@ -65,7 +69,7 @@ def _NLP_EN():  # noqa: N802 - matches the previous module-global name
 # Preserve the historical attribute name as a callable proxy. ``NLP_EN(text)``
 # triggers the lazy load on first invocation while ``NLP_EN`` continues to be
 # importable from this module.
-NLP_EN = lambda text: _load_spacy_pipeline(DEFAULT_SPACY_MODEL)(text)  # noqa: E731
+NLP_EN = lambda text: _load_spacy_pipeline(DEFAULT_SPACY_MODEL)(text)  # noqa: E731 - keeps the historical ``NLP_EN(text)`` callable API while deferring spaCy import to first use
 
 
 # TODO: Refactor to support multiple languages

--- a/lexnlp/extract/ner/__init__.py
+++ b/lexnlp/extract/ner/__init__.py
@@ -146,36 +146,31 @@ def _nltk_extract(text: str) -> list[HybridNERMatch]:
     stack.
     """
 
-    from nltk import ne_chunk, pos_tag, word_tokenize  # local: keep import-free top
+    # ``TreebankWordTokenizer.span_tokenize`` returns the surface-form
+    # ``(start, end)`` offsets directly, sidestepping the
+    # ``word_tokenize`` / ``text.find`` mismatch that occurs whenever the
+    # tokenizer normalises characters (e.g. ``"`` -> `` `` `` / ``''``).
+    from nltk import ne_chunk, pos_tag
+    from nltk.tokenize import TreebankWordTokenizer
 
-    tokens = list(word_tokenize(text))
-    if not tokens:
+    tokenizer = TreebankWordTokenizer()
+    spans = list(tokenizer.span_tokenize(text))
+    if not spans:
         return []
+    tokens = [text[s:e] for s, e in spans]
     tagged = pos_tag(tokens)
     tree = ne_chunk(tagged, binary=False)
 
     matches: list[HybridNERMatch] = []
-    cursor = 0
+    token_idx = 0
     for chunk in tree:
-        # Sub-tree => named entity (label_, [(token, pos), ...])
         if hasattr(chunk, "label"):
-            entity_tokens = [tok for tok, _pos in chunk.leaves()]
-            if not entity_tokens:
+            num_leaves = len(chunk.leaves())
+            if num_leaves == 0 or token_idx + num_leaves > len(spans):
+                token_idx += num_leaves
                 continue
-            # Walk forward from the cursor to find the surface span.
-            start = text.find(entity_tokens[0], cursor)
-            if start == -1:
-                continue
-            end = start
-            local_cursor = start
-            for tok in entity_tokens:
-                idx = text.find(tok, local_cursor)
-                if idx == -1:
-                    end = local_cursor
-                    break
-                local_cursor = idx + len(tok)
-                end = local_cursor
-            cursor = end
+            start = spans[token_idx][0]
+            end = spans[token_idx + num_leaves - 1][1]
             matches.append(
                 HybridNERMatch(
                     start=start,
@@ -185,13 +180,9 @@ def _nltk_extract(text: str) -> list[HybridNERMatch]:
                     backend="nltk",
                 )
             )
+            token_idx += num_leaves
         else:
-            # Plain tagged token; advance the cursor past it so the next NE
-            # search starts at or after this token's surface form.
-            tok = chunk[0]
-            idx = text.find(tok, cursor)
-            if idx != -1:
-                cursor = idx + len(tok)
+            token_idx += 1
     return matches
 
 

--- a/lexnlp/extract/ner/__init__.py
+++ b/lexnlp/extract/ner/__init__.py
@@ -157,7 +157,12 @@ def _nltk_extract(text: str) -> list[HybridNERMatch]:
     spans = list(tokenizer.span_tokenize(text))
     if not spans:
         return []
-    tokens = [text[s:e] for s, e in spans]
+    # ``tokenize`` and ``span_tokenize`` are guaranteed to be aligned
+    # one-to-one. Use the *normalised* tokens (e.g. ``"`` -> `` `` `` /
+    # ``''``) for the NLP pipeline because the tagger / chunker were
+    # trained on normalised input, and use the spans for character
+    # offsets in the final matches.
+    tokens = tokenizer.tokenize(text)
     tagged = pos_tag(tokens)
     tree = ne_chunk(tagged, binary=False)
 

--- a/lexnlp/extract/pt/__init__.py
+++ b/lexnlp/extract/pt/__init__.py
@@ -29,10 +29,13 @@ __maintainer__ = "LexPredict, LLC"
 __email__ = "support@contraxsuite.com"
 
 
+from lexnlp.extract.pt.amounts import get_amount_annotations, get_amounts
+from lexnlp.extract.pt.citations import get_citation_annotations, get_citations
 from lexnlp.extract.pt.copyrights import get_copyright_annotations, get_copyrights
 from lexnlp.extract.pt.courts import get_court_annotations, get_courts
 from lexnlp.extract.pt.dates import get_date_annotations, get_dates
 from lexnlp.extract.pt.definitions import get_definition_annotations, get_definitions
+from lexnlp.extract.pt.distances import get_distance_annotations, get_distances
 from lexnlp.extract.pt.durations import get_duration_annotations, get_durations
 from lexnlp.extract.pt.identifiers import (
     get_cnpj_annotations,
@@ -43,10 +46,27 @@ from lexnlp.extract.pt.identifiers import (
 from lexnlp.extract.pt.language_tokens import PtLanguageTokens
 from lexnlp.extract.pt.money import get_money, get_money_annotations
 from lexnlp.extract.pt.percents import get_percent_annotations, get_percents
+from lexnlp.extract.pt.pii import (
+    get_email_list,
+    get_emails,
+    get_phone_annotations,
+    get_phones,
+)
+from lexnlp.extract.pt.ratios import get_ratio_annotations, get_ratios
 from lexnlp.extract.pt.regulations import get_regulation_annotations, get_regulations
+from lexnlp.extract.pt.trademarks import (
+    get_entity_suffix_annotations,
+    get_trademark_annotations,
+    get_trademarks,
+)
+from lexnlp.extract.pt.urls import get_url_annotations, get_urls
 
 __all__ = [
     "PtLanguageTokens",
+    "get_amount_annotations",
+    "get_amounts",
+    "get_citation_annotations",
+    "get_citations",
     "get_cnpj_annotations",
     "get_copyright_annotations",
     "get_copyrights",
@@ -57,14 +77,27 @@ __all__ = [
     "get_dates",
     "get_definition_annotations",
     "get_definitions",
+    "get_distance_annotations",
+    "get_distances",
     "get_duration_annotations",
     "get_durations",
+    "get_email_list",
+    "get_emails",
+    "get_entity_suffix_annotations",
     "get_identifier_annotations",
     "get_money",
     "get_money_annotations",
     "get_oab_annotations",
     "get_percent_annotations",
     "get_percents",
+    "get_phone_annotations",
+    "get_phones",
+    "get_ratio_annotations",
+    "get_ratios",
     "get_regulation_annotations",
     "get_regulations",
+    "get_trademark_annotations",
+    "get_trademarks",
+    "get_url_annotations",
+    "get_urls",
 ]

--- a/lexnlp/extract/pt/__init__.py
+++ b/lexnlp/extract/pt/__init__.py
@@ -33,6 +33,7 @@ from lexnlp.extract.pt.copyrights import get_copyright_annotations, get_copyrigh
 from lexnlp.extract.pt.courts import get_court_annotations, get_courts
 from lexnlp.extract.pt.dates import get_date_annotations, get_dates
 from lexnlp.extract.pt.definitions import get_definition_annotations, get_definitions
+from lexnlp.extract.pt.durations import get_duration_annotations, get_durations
 from lexnlp.extract.pt.identifiers import (
     get_cnpj_annotations,
     get_cpf_annotations,
@@ -40,6 +41,8 @@ from lexnlp.extract.pt.identifiers import (
     get_oab_annotations,
 )
 from lexnlp.extract.pt.language_tokens import PtLanguageTokens
+from lexnlp.extract.pt.money import get_money, get_money_annotations
+from lexnlp.extract.pt.percents import get_percent_annotations, get_percents
 from lexnlp.extract.pt.regulations import get_regulation_annotations, get_regulations
 
 __all__ = [
@@ -54,8 +57,14 @@ __all__ = [
     "get_dates",
     "get_definition_annotations",
     "get_definitions",
+    "get_duration_annotations",
+    "get_durations",
     "get_identifier_annotations",
+    "get_money",
+    "get_money_annotations",
     "get_oab_annotations",
+    "get_percent_annotations",
+    "get_percents",
     "get_regulation_annotations",
     "get_regulations",
 ]

--- a/lexnlp/extract/pt/amounts.py
+++ b/lexnlp/extract/pt/amounts.py
@@ -66,7 +66,10 @@ _TENS = {
     "vinte": 20,
     "trinta": 30,
     "quarenta": 40,
-    "cinquenta": 50, "cincoenta": 50,  # legacy spelling
+    # ``cinqüenta`` is the pre-1990-Acordo-Ortográfico spelling (with
+    # trema), still common in older Brazilian legal documents and OCR;
+    # ``cincoenta`` is an older popular variant.
+    "cinquenta": 50, "cinqüenta": 50, "cincoenta": 50,
     "sessenta": 60,
     "setenta": 70,
     "oitenta": 80,

--- a/lexnlp/extract/pt/amounts.py
+++ b/lexnlp/extract/pt/amounts.py
@@ -206,7 +206,13 @@ def text_to_number(text: str) -> Decimal | None:
                 j += 1
             if j < len(tokens) and tokens[j] in _MULTIPLIERS:
                 mult = Decimal(_MULTIPLIERS[tokens[j]])
-                total += frac * mult
+                if current != 0:
+                    # "um e meio milhão" -> (1 + 0.5) * 1_000_000 = 1_500_000
+                    total += (current + frac) * mult
+                    current = Decimal(0)
+                else:
+                    # "meio milhão" -> 0.5 * 1_000_000 = 500_000
+                    total += frac * mult
                 last_mult = mult
                 i = j  # advance past the consumed multiplier
             else:

--- a/lexnlp/extract/pt/amounts.py
+++ b/lexnlp/extract/pt/amounts.py
@@ -1,0 +1,295 @@
+"""Amount extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.amounts`, tuned to Brazilian Portuguese
+formatting (``.`` as thousands separator, ``,`` as the decimal mark) and
+to the full pt-BR cardinal vocabulary up through ``trilhão`` /
+``trilhões``. Recognises:
+
+- Numeric forms: ``1.234,56``, ``12,5``, ``100``.
+- Pure word forms: ``cento e vinte e cinco``, ``mil duzentos e cinquenta``,
+  ``dois milhões e quinhentos mil``, ``um trilhão e meio bilhão``.
+- Mixed forms: ``5 milhões``, ``2,5 bilhões``, ``1,2 trilhão``.
+
+Anything outside this vocabulary is reported as a single ``None`` amount
+so callers can decide whether to fall back to a different parser.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import regex as re
+
+from lexnlp.extract.common.annotations.amount_annotation import AmountAnnotation
+
+# ---------------------------------------------------------------------------
+# pt-BR cardinal vocabulary (up to ``trilhão`` / ``trilhões``)
+# ---------------------------------------------------------------------------
+
+# Units (0-9). ``um/uma`` and ``dois/duas`` carry gender; we accept both
+# spellings transparently.
+_UNITS = {
+    "zero": 0,
+    "um": 1, "uma": 1,
+    "dois": 2, "duas": 2,
+    "três": 3, "tres": 3,  # "tres" is the unaccented OCR fallback
+    "quatro": 4,
+    "cinco": 5,
+    "seis": 6,
+    "sete": 7,
+    "oito": 8,
+    "nove": 9,
+}
+
+# Teens (10-19). ``catorze``/``quatorze`` are both standard; we accept both.
+_TEENS = {
+    "dez": 10,
+    "onze": 11,
+    "doze": 12,
+    "treze": 13,
+    "catorze": 14, "quatorze": 14,
+    "quinze": 15,
+    "dezesseis": 16, "dezasseis": 16,  # dezasseis = pt-PT spelling
+    "dezessete": 17, "dezassete": 17,
+    "dezoito": 18,
+    "dezenove": 19, "dezanove": 19,
+}
+
+_TENS = {
+    "vinte": 20,
+    "trinta": 30,
+    "quarenta": 40,
+    "cinquenta": 50, "cincoenta": 50,  # legacy spelling
+    "sessenta": 60,
+    "setenta": 70,
+    "oitenta": 80,
+    "noventa": 90,
+}
+
+# Hundreds. ``cem`` is the bare form (= 100); ``cento`` is the bound form
+# used when followed by tens/units (``cento e dois``).
+_HUNDREDS = {
+    "cem": 100,
+    "cento": 100,
+    "duzentos": 200, "duzentas": 200,
+    "trezentos": 300, "trezentas": 300,
+    "quatrocentos": 400, "quatrocentas": 400,
+    "quinhentos": 500, "quinhentas": 500,
+    "seiscentos": 600, "seiscentas": 600,
+    "setecentos": 700, "setecentas": 700,
+    "oitocentos": 800, "oitocentas": 800,
+    "novecentos": 900, "novecentas": 900,
+}
+
+_SMALL = {**_UNITS, **_TEENS, **_TENS, **_HUNDREDS}
+
+# Big-scale multipliers. ``mil`` is invariant; ``milhão`` etc. take a
+# plural form when ≥ 2.
+_MULTIPLIERS = {
+    "mil": 1000,
+    "milhão": 1_000_000, "milhao": 1_000_000,
+    "milhões": 1_000_000, "milhoes": 1_000_000,
+    "bilhão": 1_000_000_000, "bilhao": 1_000_000_000,
+    "bilhões": 1_000_000_000, "bilhoes": 1_000_000_000,
+    "trilhão": 1_000_000_000_000, "trilhao": 1_000_000_000_000,
+    "trilhões": 1_000_000_000_000, "trilhoes": 1_000_000_000_000,
+}
+
+# Halves and quarters are common in legal writing ("um milhão e meio").
+_FRACTIONS = {
+    "meio": Decimal("0.5"), "meia": Decimal("0.5"),
+    "metade": Decimal("0.5"),
+    "terço": Decimal("1") / Decimal("3"), "terco": Decimal("1") / Decimal("3"),
+    "quarto": Decimal("0.25"),
+    "quartos": Decimal("0.25"),
+}
+
+# Combined word list, longest-first so the regex prefers ``trezentos`` over
+# ``trez`` etc. The regex also matches the connector ``e`` between parts.
+_WORD_TOKENS = sorted(
+    set(_SMALL) | set(_MULTIPLIERS) | set(_FRACTIONS) | {"e"},
+    key=len,
+    reverse=True,
+)
+_WORD_PTN = "|".join(re.escape(t) for t in _WORD_TOKENS)
+# Recognises a contiguous run of pt-BR number words with optional ``e``
+# connectors and inter-token whitespace / hyphens (``vinte-e-um``).
+_WORD_NUMBER_RE = re.compile(
+    rf"(?<!\w)(?:{_WORD_PTN})(?:[\s-]+(?:{_WORD_PTN}))*(?!\w)",
+    re.UNICODE | re.IGNORECASE,
+)
+
+# Brazilian-numeric fragment, optionally followed by a multiplier word
+# ("2,5 milhões", "1.234,56 mil"). We match this *before* the bare
+# word-only matcher so the multiplier is consumed only once.
+_PT_NUMBER_PTN = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?"
+_MULT_RE_PART = "|".join(
+    re.escape(t) for t in sorted(_MULTIPLIERS, key=len, reverse=True)
+)
+_NUM_WITH_MULT_RE = re.compile(
+    rf"(?<![\w.])(?P<num>{_PT_NUMBER_PTN})\s+(?P<mult>{_MULT_RE_PART})(?!\w)",
+    re.UNICODE | re.IGNORECASE,
+)
+_PLAIN_NUMBER_RE = re.compile(rf"(?<![\w.,])(?P<num>{_PT_NUMBER_PTN})(?!\d)")
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_pt_number(raw: str) -> Decimal:
+    """Convert a Brazilian-formatted numeric string to :class:`Decimal`."""
+    return Decimal(raw.replace(".", "").replace(",", "."))
+
+
+def text_to_number(text: str) -> Decimal | None:
+    """Convert a Portuguese cardinal phrase to :class:`Decimal`.
+
+    Accepts everything from ``"um"`` up through ``"um trilhão e quinhentos
+    bilhões"``. Returns ``None`` for empty or unrecognisable input.
+
+    The algorithm is the standard sum-product walk over tokens:
+
+    * units / teens / tens / hundreds accumulate into ``current``;
+    * a multiplier (``mil``, ``milhão`` …) commits ``current`` (or 1 if
+      empty, so bare ``mil`` -> 1000) and resets it;
+    * the connector ``"e"`` is ignored; a trailing ``"e meio"`` /
+      ``"e meia"`` adds ½ of the most recent multiplier section.
+    """
+    if not text:
+        return None
+    tokens = re.findall(r"\w+", text.lower(), flags=re.UNICODE)
+    if not tokens:
+        return None
+
+    total = Decimal(0)
+    current = Decimal(0)
+    last_mult = Decimal(1)
+    saw_anything = False
+
+    for tok in tokens:
+        if tok == "e":
+            continue
+        if tok in _SMALL:
+            current += Decimal(_SMALL[tok])
+            saw_anything = True
+        elif tok in _MULTIPLIERS:
+            mult = Decimal(_MULTIPLIERS[tok])
+            if current == 0:
+                current = Decimal(1)
+            total += current * mult
+            current = Decimal(0)
+            last_mult = mult
+            saw_anything = True
+        elif tok in _FRACTIONS:
+            # "meio milhão" without preceding number = half of the last
+            # multiplier; "e meio" after a multiplier section also adds
+            # half of that scale (e.g. "um milhão e meio" -> 1_500_000).
+            frac = _FRACTIONS[tok]
+            total += frac * last_mult
+            saw_anything = True
+        else:
+            # Unknown token; bail and let callers decide what to do.
+            return None
+
+    return (total + current) if saw_anything else None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_amount_annotations(
+    text: str, float_digits: int = 4
+) -> Iterator[AmountAnnotation]:
+    """Yield :class:`AmountAnnotation` for every numeric/word amount in *text*.
+
+    Order: numeric-with-multiplier matches first (``2,5 milhões``), then
+    plain numerics, then word-only phrases. Spans already covered by an
+    earlier match are skipped to avoid duplicates.
+    """
+    seen_spans: list[tuple[int, int]] = []
+
+    def _is_dup(span: tuple[int, int]) -> bool:
+        return any(s <= span[0] and span[1] <= e for s, e in seen_spans)
+
+    # 1) "<number> <multiplier>"
+    for match in _NUM_WITH_MULT_RE.finditer(text):
+        span = match.span()
+        seen_spans.append(span)
+        amount = _parse_pt_number(match.group("num")) * Decimal(
+            _MULTIPLIERS[match.group("mult").lower()]
+        )
+        if float_digits:
+            amount = round(amount, float_digits)
+        yield AmountAnnotation(coords=span, text=match.group(), value=amount, locale="pt")
+
+    # 2) word-only phrases ("cento e vinte e cinco")
+    for match in _WORD_NUMBER_RE.finditer(text):
+        span = match.span()
+        if _is_dup(span):
+            continue
+        # Reject single-token "e" matches (the regex allows leading "e"
+        # because it appears in the alternation; just skip those).
+        phrase = match.group()
+        stripped = phrase.strip()
+        if stripped.lower() == "e":
+            continue
+        value = text_to_number(stripped)
+        if value is None:
+            continue
+        seen_spans.append(span)
+        if float_digits:
+            value = round(value, float_digits)
+        yield AmountAnnotation(coords=span, text=phrase, value=value, locale="pt")
+
+    # 3) plain numerics
+    for match in _PLAIN_NUMBER_RE.finditer(text):
+        span = match.span("num")
+        if _is_dup(span):
+            continue
+        amount = _parse_pt_number(match.group("num"))
+        if float_digits:
+            amount = round(amount, float_digits)
+        yield AmountAnnotation(coords=span, text=match.group("num"), value=amount, locale="pt")
+
+
+def get_amounts(text: str, float_digits: int = 4) -> Iterator[Decimal]:
+    """Yield only the :class:`Decimal` values found in *text*."""
+    for ant in get_amount_annotations(text, float_digits):
+        yield ant.value
+
+
+def get_amount_annotation_list(
+    text: str, float_digits: int = 4
+) -> list[AmountAnnotation]:
+    """Return all :class:`AmountAnnotation` instances for *text* as a list."""
+    return list(get_amount_annotations(text, float_digits))
+
+
+def get_amount_list(text: str, float_digits: int = 4) -> list[Decimal]:
+    """Return all amounts in *text* as a list of :class:`Decimal`."""
+    return list(get_amounts(text, float_digits))
+
+
+# Public number pattern, exposed so dependent modules (``distances``,
+# ``ratios``, ``money``) can reuse the canonical pt-BR numeric form.
+NUM_PTN: str = _PT_NUMBER_PTN
+
+__all__ = [
+    "NUM_PTN",
+    "get_amount_annotation_list",
+    "get_amount_annotations",
+    "get_amount_list",
+    "get_amounts",
+    "text_to_number",
+]

--- a/lexnlp/extract/pt/amounts.py
+++ b/lexnlp/extract/pt/amounts.py
@@ -178,8 +178,11 @@ def text_to_number(text: str) -> Decimal | None:
     last_mult = Decimal(1)
     saw_anything = False
 
-    for tok in tokens:
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
         if tok == "e":
+            i += 1
             continue
         if tok in _SMALL:
             current += Decimal(_SMALL[tok])
@@ -193,15 +196,29 @@ def text_to_number(text: str) -> Decimal | None:
             last_mult = mult
             saw_anything = True
         elif tok in _FRACTIONS:
-            # "meio milhão" without preceding number = half of the last
-            # multiplier; "e meio" after a multiplier section also adds
-            # half of that scale (e.g. "um milhão e meio" -> 1_500_000).
             frac = _FRACTIONS[tok]
-            total += frac * last_mult
+            # Look ahead one token (skipping a connector "e") for a
+            # multiplier so "meio milhão" / "meia bilhão" resolve to
+            # 500_000 / 500_000_000 instead of 0.5 (which would be the
+            # result of using ``last_mult`` = 1 at that point).
+            j = i + 1
+            if j < len(tokens) and tokens[j] == "e":
+                j += 1
+            if j < len(tokens) and tokens[j] in _MULTIPLIERS:
+                mult = Decimal(_MULTIPLIERS[tokens[j]])
+                total += frac * mult
+                last_mult = mult
+                i = j  # advance past the consumed multiplier
+            else:
+                # "um milhão e meio" -> add half of the most-recent
+                # multiplier scale; bare "meio" with no context falls
+                # back to multiplier = 1 (i.e. the literal value 0.5).
+                total += frac * last_mult
             saw_anything = True
         else:
             # Unknown token; bail and let callers decide what to do.
             return None
+        i += 1
 
     return (total + current) if saw_anything else None
 

--- a/lexnlp/extract/pt/citations.py
+++ b/lexnlp/extract/pt/citations.py
@@ -49,9 +49,10 @@ _REPORTERS = [
 _REPORTERS_SORTED = sorted(_REPORTERS, key=len, reverse=True)
 _REPORTER_PART = "|".join(re.escape(r) for r in _REPORTERS_SORTED)
 
-# Numeric body: ``12.345``, ``123.456``, ``999``, with optional UF
-# suffix ``/SP``, ``/RJ`` etc. and optional year ``/2020``.
-_NUMBER_PART = r"\d{1,3}(?:\.\d{3})*"
+# Numeric body: ``12.345``, ``123.456``, ``999``, ``MS 12345``,
+# ``CC 12345`` — accept either grouped form (with thousands dots) OR
+# ungrouped runs of 4+ digits common in older case-law citations.
+_NUMBER_PART = r"(?:\d{1,3}(?:\.\d{3})*|\d{4,})"
 _UF_LIST = (
     "AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|"
     "RJ|RN|RO|RR|RS|SC|SE|SP|TO"

--- a/lexnlp/extract/pt/citations.py
+++ b/lexnlp/extract/pt/citations.py
@@ -1,0 +1,176 @@
+"""Case-citation extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.citations`, tuned to the Brazilian
+appellate-court citation forms most commonly seen in legal writing:
+
+- Supremo Tribunal Federal: ``ADI 1.234``, ``ADC 56``, ``ADPF 132``,
+  ``RE 123.456``, ``ARE 654.321``, ``HC 999``, ``MS 12345``.
+- Superior Tribunal de Justiça: ``REsp 12.345``, ``AgRg no AREsp 234.567``,
+  ``EREsp 99.999``, ``HC 88.888``, ``RHC 77.777``.
+- Tribunais Superiores: ``CC 12345`` (conflito de competência),
+  ``IUJur 1234`` (incidente de uniformização), ``MI 99``.
+- Justiça do Trabalho: ``RR 1234-56.2020.5.04.0001``,
+  ``AIRR 12345-67.2019.5.10.0009`` (CNJ-format process numbers).
+
+Each match is reported as a :class:`CitationAnnotation`. The
+``reporter`` field carries the Brazilian abbreviation (e.g. ``REsp``)
+and ``source`` holds the canonical case identifier (digits-and-slashes
+form). For CNJ-format process numbers we additionally split out the
+year, instance ("5"), regional segment and unit number into
+``volume_str`` for downstream consumers.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+
+import regex as re
+
+from lexnlp.extract.common.annotations.citation_annotation import CitationAnnotation
+
+# Brazilian court reporter abbreviations recognised by the regex. Order
+# matters: longest tokens come first so e.g. ``AREsp`` is consumed before
+# ``RE``.
+_REPORTERS = [
+    # STJ family
+    "AgRg no AREsp", "AgInt no AREsp", "AgRg no REsp", "AgInt no REsp",
+    "EDcl no REsp", "EREsp", "AREsp", "REsp", "RHC", "RMS",
+    # STF family
+    "ADPF", "ADI", "ADC", "ADO", "ARE", "RE", "HC", "MS", "MI",
+    # Tribunais Superiores
+    "IUJur", "CC", "ED", "QO",
+]
+_REPORTERS_SORTED = sorted(_REPORTERS, key=len, reverse=True)
+_REPORTER_PART = "|".join(re.escape(r) for r in _REPORTERS_SORTED)
+
+# Numeric body: ``12.345``, ``123.456``, ``999``, with optional UF
+# suffix ``/SP``, ``/RJ`` etc. and optional year ``/2020``.
+_NUMBER_PART = r"\d{1,3}(?:\.\d{3})*"
+_UF_LIST = (
+    "AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|"
+    "RJ|RN|RO|RR|RS|SC|SE|SP|TO"
+)
+_YEAR_PART = r"\d{2,4}"
+
+# "REsp 12.345/SP", "RE 123.456", "ADI 1.234"
+CASE_CITATION_RE = re.compile(
+    rf"(?<![\w./])(?P<full>(?P<reporter>{_REPORTER_PART})\s+"
+    rf"(?P<source>(?P<number>{_NUMBER_PART})"
+    rf"(?:/(?P<uf>{_UF_LIST}))?"
+    rf"(?:[/\s](?P<year>{_YEAR_PART}))?"
+    rf"))(?!\d)",
+    re.UNICODE,
+)
+
+# CNJ-format process number, mandatory since 2010 across all Brazilian
+# courts: NNNNNNN-DD.AAAA.J.TR.OOOO (7-2-4-1-2-4 digits with separators).
+CNJ_PROCESS_RE = re.compile(
+    r"(?<!\d)"
+    r"(?P<full>(?P<sequencial>\d{7})-(?P<digito>\d{2})\."
+    r"(?P<ano>\d{4})\.(?P<segmento>\d)\.(?P<tribunal>\d{2})\.(?P<origem>\d{4}))"
+    r"(?!\d)"
+)
+
+
+def _parse_int(value: str | None) -> int | None:
+    """Convert ``value`` to ``int`` after stripping thousands separators."""
+    if value is None:
+        return None
+    digits = value.replace(".", "")
+    return int(digits) if digits.isdigit() else None
+
+
+def _normalise_year(value: str | None) -> int | None:
+    """Coerce a 2- or 4-digit year string to the canonical 4-digit form."""
+    if value is None:
+        return None
+    if len(value) == 2 and value.isdigit():
+        # Treat ``/85`` as 1985 and ``/20`` as 2020 — Brazilian case-law
+        # citations span the 20th and 21st century, so we pivot at 50.
+        n = int(value)
+        return 1900 + n if n >= 50 else 2000 + n
+    return _parse_int(value)
+
+
+def get_case_citation_annotations(text: str) -> Iterator[CitationAnnotation]:
+    """Yield :class:`CitationAnnotation` for short-form Brazilian case cites."""
+    for match in CASE_CITATION_RE.finditer(text):
+        yield CitationAnnotation(
+            coords=match.span("full"),
+            text=match.group("full"),
+            reporter=match.group("reporter"),
+            source=match.group("source"),
+            volume=_parse_int(match.group("number")),
+            year=_normalise_year(match.group("year")),
+            court=match.group("uf"),
+            locale="pt",
+        )
+
+
+def get_cnj_process_annotations(text: str) -> Iterator[CitationAnnotation]:
+    """Yield :class:`CitationAnnotation` for CNJ-format process numbers.
+
+    The CNJ process number embeds the year, judicial segment, regional
+    tribunal and unit of origin; we parse them out into the annotation's
+    ``year`` / ``volume_str`` fields so they're inspectable without
+    re-parsing the source string.
+    """
+    for match in CNJ_PROCESS_RE.finditer(text):
+        cnj = match.groupdict()
+        # ``volume_str`` carries the structural breakdown so callers can
+        # display it cleanly without re-parsing.
+        volume_str = (
+            f"seg={cnj['segmento']} tr={cnj['tribunal']} orig={cnj['origem']}"
+        )
+        yield CitationAnnotation(
+            coords=match.span("full"),
+            text=match.group("full"),
+            source=match.group("full"),
+            year=int(cnj["ano"]),
+            volume_str=volume_str,
+            locale="pt",
+        )
+
+
+def get_citation_annotations(text: str) -> Iterator[CitationAnnotation]:
+    """Yield every Brazilian case citation we know how to extract.
+
+    Order: short-form abbreviations first (``REsp 12.345``), then CNJ
+    process numbers (``1234567-89.2020.8.26.0100``).
+    """
+    yield from get_case_citation_annotations(text)
+    yield from get_cnj_process_annotations(text)
+
+
+def get_citations(text: str) -> Iterator[str]:
+    """Yield the surface form of every case citation in *text*."""
+    for ant in get_citation_annotations(text):
+        yield ant.text
+
+
+def get_citation_annotation_list(text: str) -> list[CitationAnnotation]:
+    """Return all citation annotations in *text* as a list."""
+    return list(get_citation_annotations(text))
+
+
+def get_citation_list(text: str) -> list[str]:
+    """Return all citation surface strings in *text* as a list."""
+    return list(get_citations(text))
+
+
+__all__ = [
+    "CASE_CITATION_RE",
+    "CNJ_PROCESS_RE",
+    "get_case_citation_annotations",
+    "get_citation_annotation_list",
+    "get_citation_annotations",
+    "get_citation_list",
+    "get_citations",
+    "get_cnj_process_annotations",
+]

--- a/lexnlp/extract/pt/citations.py
+++ b/lexnlp/extract/pt/citations.py
@@ -9,8 +9,9 @@ appellate-court citation forms most commonly seen in legal writing:
   ``EREsp 99.999``, ``HC 88.888``, ``RHC 77.777``.
 - Tribunais Superiores: ``CC 12345`` (conflito de competência),
   ``IUJur 1234`` (incidente de uniformização), ``MI 99``.
-- Justiça do Trabalho: ``RR 1234-56.2020.5.04.0001``,
-  ``AIRR 12345-67.2019.5.10.0009`` (CNJ-format process numbers).
+- Justiça do Trabalho: ``RR 1234567-56.2020.5.04.0001``,
+  ``AIRR 1234567-67.2019.5.10.0009`` (CNJ-format process numbers — the
+  sequencial component is always 7 digits per Resolução CNJ 65/2008).
 
 Each match is reported as a :class:`CitationAnnotation`. The
 ``reporter`` field carries the Brazilian abbreviation (e.g. ``REsp``)

--- a/lexnlp/extract/pt/definitions.py
+++ b/lexnlp/extract/pt/definitions.py
@@ -141,20 +141,23 @@ class PortugueseParsingMethods:
     def match_pt_def_by_parenthesised_label(phrase: str) -> list[PatternFound]:
         """Match Brazilian-contract parenthesised quoted labels like ``(o "Contratante")``.
 
-        Each match is reported with the quoted label as the defined name and
-        the surrounding parenthesised group as the surface form. ``ou``-joined
-        alternatives (``(o "Locador" ou "Locatário")``) all share the same
-        coordinates because they belong to the same definition cue.
+        Each quoted label is reported as a separate :class:`PatternFound`
+        whose ``name`` is the unquoted label text. ``ou``-joined alternatives
+        (``(o "Locador" ou "Locatário")``) yield one :class:`PatternFound`
+        per quoted alternative, all sharing the same start/end coordinates
+        of the surrounding parenthesised group.
         """
         results: list[PatternFound] = []
         for match in PortugueseParsingMethods.reg_parenthesised_label.finditer(phrase):
             start, end = match.span()
-            entry = PatternFound()
-            entry.name = "parenthesised_label"
-            entry.start = start
-            entry.end = end
-            entry.probability = 85
-            results.append(entry)
+            labels = re.findall(r'"([^"]+)"', match.group(0))
+            for label in labels:
+                entry = PatternFound()
+                entry.name = label.strip()
+                entry.start = start
+                entry.end = end
+                entry.probability = 85
+                results.append(entry)
         return results
 
     @staticmethod

--- a/lexnlp/extract/pt/distances.py
+++ b/lexnlp/extract/pt/distances.py
@@ -1,0 +1,128 @@
+"""Distance extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.distances`, swapping the unit dictionary
+to the Brazilian Portuguese lexicon and reusing the canonical pt-BR
+number pattern from :mod:`lexnlp.extract.pt.amounts` (``NUM_PTN``).
+
+Recognised units: kilometres, metres, centimetres, millimetres, miles
+(``milha`` / ``milhas``), nautical miles, yards, feet and inches — the
+last three are common in technical specifications imported from English
+sources.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import regex as re
+
+from lexnlp.extract.common.annotations.distance_annotation import DistanceAnnotation
+from lexnlp.extract.pt.amounts import NUM_PTN, _parse_pt_number  # noqa: PLC2701 - reuse pt number parser
+
+# Symbol -> canonical English unit name (matches the EN convention so the
+# annotation's ``distance_type`` stays comparable across locales).
+DISTANCE_SYMBOL_MAP: dict[str, str] = {
+    "km": "kilometer",
+    "m": "meter",
+    "cm": "centimeter",
+    "mm": "millimeter",
+    "mi": "mile",
+    "yd": "yard",
+    "ft": "foot",
+    "in": "inch",
+    "nmi": "nautical_mile",
+}
+
+# pt-BR word -> canonical English unit name. Both singular and plural
+# forms are accepted.
+DISTANCE_TOKEN_MAP: dict[str, str] = {
+    "quilômetros": "kilometer", "quilometros": "kilometer",
+    "quilômetro": "kilometer", "quilometro": "kilometer",
+    "metros": "meter", "metro": "meter",
+    "centímetros": "centimeter", "centimetros": "centimeter",
+    "centímetro": "centimeter", "centimetro": "centimeter",
+    "milímetros": "millimeter", "milimetros": "millimeter",
+    "milímetro": "millimeter", "milimetro": "millimeter",
+    "milhas": "mile", "milha": "mile",
+    "milhas náuticas": "nautical_mile", "milha náutica": "nautical_mile",
+    "jardas": "yard", "jarda": "yard",
+    "pés": "foot", "pes": "foot", "pé": "foot",
+    "polegadas": "inch", "polegada": "inch",
+}
+
+_TOKEN_PART = "|".join(
+    re.escape(t) for t in sorted(DISTANCE_TOKEN_MAP, key=len, reverse=True)
+)
+_SYMBOL_PART = "|".join(re.escape(s) for s in DISTANCE_SYMBOL_MAP)
+
+DISTANCE_PTN_RE = re.compile(
+    rf"(?P<text>(?P<num>{NUM_PTN})\s*"
+    rf"(?P<unit>{_TOKEN_PART}|{_SYMBOL_PART}))(?:\W|$)",
+    re.IGNORECASE | re.MULTILINE | re.UNICODE,
+)
+
+
+def _resolve_unit(token: str) -> str:
+    """Map a unit surface form to its canonical English name."""
+    lowered = token.lower()
+    return DISTANCE_TOKEN_MAP.get(lowered) or DISTANCE_SYMBOL_MAP.get(lowered, lowered)
+
+
+def get_distance_annotations(
+    text: str, float_digits: int = 4
+) -> Iterator[DistanceAnnotation]:
+    """Yield :class:`DistanceAnnotation` for every distance in *text*."""
+    for match in DISTANCE_PTN_RE.finditer(text):
+        amount = _parse_pt_number(match.group("num"))
+        if float_digits:
+            amount = round(amount, float_digits)
+        yield DistanceAnnotation(
+            coords=match.span("text"),
+            text=match.group("text"),
+            amount=amount,
+            distance_type=_resolve_unit(match.group("unit")),
+            locale="pt",
+        )
+
+
+def get_distances(
+    text: str, return_sources: bool = False, float_digits: int = 4
+) -> Iterator[tuple[Decimal, str] | tuple[Decimal, str, str]]:
+    """Yield ``(amount, distance_type)`` tuples (optionally with source text)."""
+    for ant in get_distance_annotations(text, float_digits):
+        if return_sources:
+            yield ant.amount, ant.distance_type, ant.text
+        else:
+            yield ant.amount, ant.distance_type
+
+
+def get_distance_annotation_list(
+    text: str, float_digits: int = 4
+) -> list[DistanceAnnotation]:
+    """Return all distance annotations in *text* as a list."""
+    return list(get_distance_annotations(text, float_digits))
+
+
+def get_distance_list(
+    text: str, return_sources: bool = False, float_digits: int = 4
+) -> list[tuple[Decimal, str] | tuple[Decimal, str, str]]:
+    """Return all distance tuples in *text* as a list."""
+    return list(get_distances(text, return_sources, float_digits))
+
+
+__all__ = [
+    "DISTANCE_PTN_RE",
+    "DISTANCE_SYMBOL_MAP",
+    "DISTANCE_TOKEN_MAP",
+    "get_distance_annotation_list",
+    "get_distance_annotations",
+    "get_distance_list",
+    "get_distances",
+]

--- a/lexnlp/extract/pt/durations.py
+++ b/lexnlp/extract/pt/durations.py
@@ -89,12 +89,22 @@ def _parse_pt_number(raw: str) -> Decimal:
     return Decimal(raw.replace(".", "").replace(",", "."))
 
 
+def _fraction_to_decimal(value: Fraction) -> Decimal:
+    """Convert a :class:`Fraction` to :class:`Decimal` exactly.
+
+    ``Decimal(Fraction(...))`` is not supported in Python 3.x — it raises
+    ``TypeError``. We instead build the Decimal as numerator / denominator,
+    which preserves the rational value without going through ``float``.
+    """
+    return Decimal(value.numerator) / Decimal(value.denominator)
+
+
 def _make_simple_annotation(match: "re.Match[str]") -> DurationAnnotation:
     """Build a single-part DurationAnnotation from one regex match."""
     raw_unit = match.group("unit").lower()
     duration_en = _PT_UNITS[raw_unit]
     amount = _parse_pt_number(match.group("num"))
-    duration_days = Decimal(_DURATION_DAYS[duration_en]) * amount
+    duration_days = _fraction_to_decimal(_DURATION_DAYS[duration_en]) * amount
     prefix = (match.group("prefix") or "").strip() or None
     return DurationAnnotation(
         coords=match.span("text"),
@@ -125,15 +135,20 @@ def _is_continuation(prev: DurationAnnotation, curr: DurationAnnotation, text: s
     return _INNER_PUNCT_RE.sub("", gap) == ""
 
 
-def _sum_group(group: list[DurationAnnotation]) -> DurationAnnotation:
-    """Merge a list of contiguous DurationAnnotations into a complex one."""
+def _sum_group(group: list[DurationAnnotation], text: str) -> DurationAnnotation:
+    """Merge a list of contiguous DurationAnnotations into a complex one.
+
+    ``text`` is the original source string; we slice it by the merged
+    coordinates so the surface preserves the gap separators ("e", "mais",
+    whitespace, punctuation) instead of dropping them by concatenation.
+    """
     coords = (group[0].coords[0], group[-1].coords[1])
     merged = DurationAnnotation(coords=coords, locale="pt", is_complex=True)
     merged.duration_days = sum((d.duration_days for d in group), start=Decimal(0))
     merged.amount = merged.duration_days
     merged.duration_type = group[-1].duration_type
     merged.duration_type_en = group[-1].duration_type_en
-    merged.text = "".join(g.text or "" for g in group)
+    merged.text = text[coords[0] : coords[1]]
     value_dict: dict[str, float] = {}
     for ant in group:
         key = ant.duration_type or ""
@@ -165,7 +180,7 @@ def get_duration_annotations(text: str) -> Iterator[DurationAnnotation]:
             group = [ant]
             grouped.append(group)
     for grp in grouped:
-        yield grp[0] if len(grp) == 1 else _sum_group(grp)
+        yield grp[0] if len(grp) == 1 else _sum_group(grp, text)
 
 
 def get_durations(text: str) -> Iterator[dict]:

--- a/lexnlp/extract/pt/durations.py
+++ b/lexnlp/extract/pt/durations.py
@@ -1,0 +1,201 @@
+"""Duration extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.de.durations`, tuned to the Brazilian
+Portuguese unit lexicon (``segundo`` / ``minuto`` / ``hora`` / ``dia`` /
+``semana`` / ``mês`` / ``trimestre`` / ``ano``) and to Brazilian numeric
+formatting (``.`` thousands, ``,`` decimal). Produces
+:class:`DurationAnnotation` records, including grouped multi-part
+expressions like ``2 anos e 6 meses``.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+from fractions import Fraction
+
+import regex as re
+
+from lexnlp.extract.common.annotations.duration_annotation import DurationAnnotation
+
+# Days per unit (matches the convention used in the DE/EN duration parsers).
+_DURATION_DAYS = {
+    "second": Fraction(1, 60 * 60 * 24),
+    "minute": Fraction(1, 60 * 24),
+    "hour": Fraction(1, 24),
+    "day": Fraction(1),
+    "week": Fraction(7),
+    "fortnight": Fraction(14),
+    "month": Fraction(30),
+    "quarter": Fraction(365, 4),
+    "semester": Fraction(365, 2),
+    "year": Fraction(365),
+}
+
+# pt-BR unit lexicon -> English duration_type (singular).
+_PT_UNITS = {
+    "segundo": "second",
+    "segundos": "second",
+    "minuto": "minute",
+    "minutos": "minute",
+    "hora": "hour",
+    "horas": "hour",
+    "dia": "day",
+    "dias": "day",
+    "semana": "week",
+    "semanas": "week",
+    "quinzena": "fortnight",
+    "quinzenas": "fortnight",
+    "mês": "month",
+    "meses": "month",
+    "mes": "month",  # OCR-friendly fallback (sem o til)
+    "trimestre": "quarter",
+    "trimestres": "quarter",
+    "semestre": "semester",
+    "semestres": "semester",
+    "ano": "year",
+    "anos": "year",
+}
+
+_UNIT_PART = "|".join(sorted(_PT_UNITS.keys(), key=len, reverse=True))
+
+# Brazilian number: optional ``.`` thousands groups, optional ``,`` decimal.
+_PT_NUMBER_PTN = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?"
+
+# Optional prefix ("aproximadamente", "cerca de", "no mínimo", "no máximo")
+_PREFIX_PTN = (
+    r"(?:aproximadamente|cerca\s+de|no\s+m[ií]nimo|no\s+m[áa]ximo|pelo\s+menos|"
+    r"até|aprox\.|aprox)?"
+)
+
+DURATION_PTN_RE = re.compile(
+    rf"(?P<text>(?:(?P<prefix>{_PREFIX_PTN})\s*)?"
+    rf"(?P<num>{_PT_NUMBER_PTN})\s+(?P<unit>{_UNIT_PART}))",
+    re.IGNORECASE | re.UNICODE,
+)
+
+_INNER_CONJUNCTIONS = ("e", "mais", "y")
+_INNER_PUNCT_RE = re.compile(r"[\s,;.]+")
+
+
+def _parse_pt_number(raw: str) -> Decimal:
+    """Convert a Brazilian-formatted numeric string to :class:`Decimal`."""
+    return Decimal(raw.replace(".", "").replace(",", "."))
+
+
+def _make_simple_annotation(match: "re.Match[str]") -> DurationAnnotation:
+    """Build a single-part DurationAnnotation from one regex match."""
+    raw_unit = match.group("unit").lower()
+    duration_en = _PT_UNITS[raw_unit]
+    amount = _parse_pt_number(match.group("num"))
+    duration_days = Decimal(_DURATION_DAYS[duration_en]) * amount
+    prefix = (match.group("prefix") or "").strip() or None
+    return DurationAnnotation(
+        coords=match.span("text"),
+        locale="pt",
+        text=match.group("text"),
+        amount=amount,
+        prefix=prefix,
+        duration_days=duration_days,
+        duration_type=raw_unit,
+        duration_type_en=duration_en,
+    )
+
+
+def _is_continuation(prev: DurationAnnotation, curr: DurationAnnotation, text: str) -> bool:
+    """Return True when *curr* should be grouped with *prev* into one duration.
+
+    Continuation requires the second unit to be strictly shorter than the
+    first and the gap between matches to contain only whitespace,
+    punctuation, or an accepted Portuguese conjunction.
+    """
+    prev_days = _DURATION_DAYS.get(prev.duration_type_en, Fraction(1))
+    curr_days = _DURATION_DAYS.get(curr.duration_type_en, Fraction(1))
+    if curr_days >= prev_days:
+        return False
+    gap = text[prev.coords[1] : curr.coords[0]].lower()
+    for conj in _INNER_CONJUNCTIONS:
+        gap = re.sub(rf"\b{conj}\b", "", gap)
+    return _INNER_PUNCT_RE.sub("", gap) == ""
+
+
+def _sum_group(group: list[DurationAnnotation]) -> DurationAnnotation:
+    """Merge a list of contiguous DurationAnnotations into a complex one."""
+    coords = (group[0].coords[0], group[-1].coords[1])
+    merged = DurationAnnotation(coords=coords, locale="pt", is_complex=True)
+    merged.duration_days = sum((d.duration_days for d in group), start=Decimal(0))
+    merged.amount = merged.duration_days
+    merged.duration_type = group[-1].duration_type
+    merged.duration_type_en = group[-1].duration_type_en
+    merged.text = "".join(g.text or "" for g in group)
+    value_dict: dict[str, float] = {}
+    for ant in group:
+        key = ant.duration_type or ""
+        value_dict[key] = value_dict.get(key, 0.0) + float(ant.amount or 0)
+    merged.value_dict = value_dict
+    return merged
+
+
+def get_duration_annotations(text: str) -> Iterator[DurationAnnotation]:
+    """Yield :class:`DurationAnnotation` records for *text*.
+
+    Adjacent matches that progress from a longer to a shorter unit and are
+    separated only by punctuation / conjunctions (``e``, ``mais``) are
+    grouped into a single ``is_complex=True`` annotation whose
+    ``duration_days`` is the sum of the parts.
+    """
+    flat = [_make_simple_annotation(m) for m in DURATION_PTN_RE.finditer(text)]
+    if not flat:
+        return
+    if len(flat) == 1:
+        yield flat[0]
+        return
+    group: list[DurationAnnotation] = [flat[0]]
+    grouped: list[list[DurationAnnotation]] = [group]
+    for ant in flat[1:]:
+        if _is_continuation(group[-1], ant, text):
+            group.append(ant)
+        else:
+            group = [ant]
+            grouped.append(group)
+    for grp in grouped:
+        yield grp[0] if len(grp) == 1 else _sum_group(grp)
+
+
+def get_durations(text: str) -> Iterator[dict]:
+    """Yield dictionaries describing each duration expression in *text*."""
+    for ant in get_duration_annotations(text):
+        yield {
+            "location_start": ant.coords[0],
+            "location_end": ant.coords[1],
+            "source_text": ant.text,
+            "amount": ant.amount,
+            "duration_type": ant.duration_type,
+            "duration_days": ant.duration_days,
+            "is_complex": ant.is_complex,
+        }
+
+
+def get_duration_annotation_list(text: str) -> list[DurationAnnotation]:
+    """Return all duration annotations in *text* as a list."""
+    return list(get_duration_annotations(text))
+
+
+def get_duration_list(text: str) -> list[dict]:
+    """Return all duration annotations as a list of plain dictionaries."""
+    return list(get_durations(text))
+
+
+__all__ = [
+    "DURATION_PTN_RE",
+    "get_duration_annotation_list",
+    "get_duration_annotations",
+    "get_duration_list",
+    "get_durations",
+]

--- a/lexnlp/extract/pt/durations.py
+++ b/lexnlp/extract/pt/durations.py
@@ -69,13 +69,19 @@ _UNIT_PART = "|".join(sorted(_PT_UNITS.keys(), key=len, reverse=True))
 _PT_NUMBER_PTN = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?"
 
 # Optional prefix ("aproximadamente", "cerca de", "no mínimo", "no máximo")
+# — note the inner alternation is NOT made optional here: the outer
+# pattern wraps it with ``?`` so an empty prefix never matches while
+# silently consuming the whitespace before the number.
 _PREFIX_PTN = (
     r"(?:aproximadamente|cerca\s+de|no\s+m[ií]nimo|no\s+m[áa]ximo|pelo\s+menos|"
-    r"até|aprox\.|aprox)?"
+    r"até|aprox\.|aprox)"
 )
 
 DURATION_PTN_RE = re.compile(
-    rf"(?P<text>(?:(?P<prefix>{_PREFIX_PTN})\s*)?"
+    # When the optional prefix is present, require ``\s+`` after it so an
+    # empty prefix can't silently consume leading whitespace before the
+    # number (which would push the ``text`` span back by one char).
+    rf"(?P<text>(?:(?P<prefix>{_PREFIX_PTN})\s+)?"
     rf"(?P<num>{_PT_NUMBER_PTN})\s+(?P<unit>{_UNIT_PART}))",
     re.IGNORECASE | re.UNICODE,
 )
@@ -122,14 +128,20 @@ def _is_continuation(prev: DurationAnnotation, curr: DurationAnnotation, text: s
     """Return True when *curr* should be grouped with *prev* into one duration.
 
     Continuation requires the second unit to be strictly shorter than the
-    first and the gap between matches to contain only whitespace,
+    first AND the gap between matches to contain neither a sentence
+    terminator (``.``/``!``/``?``) nor anything beyond whitespace,
     punctuation, or an accepted Portuguese conjunction.
     """
     prev_days = _DURATION_DAYS.get(prev.duration_type_en, Fraction(1))
     curr_days = _DURATION_DAYS.get(curr.duration_type_en, Fraction(1))
     if curr_days >= prev_days:
         return False
-    gap = text[prev.coords[1] : curr.coords[0]].lower()
+    gap = text[prev.coords[1] : curr.coords[0]]
+    # A sentence terminator in the gap means the second match starts a
+    # new clause/sentence, so it must not be merged with the first.
+    if any(ch in gap for ch in ".!?"):
+        return False
+    gap = gap.lower()
     for conj in _INNER_CONJUNCTIONS:
         gap = re.sub(rf"\b{conj}\b", "", gap)
     return _INNER_PUNCT_RE.sub("", gap) == ""

--- a/lexnlp/extract/pt/money.py
+++ b/lexnlp/extract/pt/money.py
@@ -65,9 +65,11 @@ _CURRENCY_SYMBOL_RE_PART = "R\\$|US\\$|\\$|€|£|¥"
 # fraction (e.g. "1.234,56" / "12,5" / "100").
 _PT_NUMBER_PTN = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?"
 
-# Symbol/code prefix: "R$ 100,00", "USD 1.234,56".
+# Symbol/code prefix: "R$ 100,00", "USD 1.234,56". The leading
+# ``(?<!\w)`` lookbehind prevents matches inside larger tokens like
+# ``XBRL100`` (which would otherwise yield a spurious ``BRL100`` match).
 _MONEY_PREFIX_RE = re.compile(
-    rf"(?P<text>(?P<currency>{_CURRENCY_SYMBOL_RE_PART}|{_CURRENCY_CODE_RE_PART})\s*"
+    rf"(?<!\w)(?P<text>(?P<currency>{_CURRENCY_SYMBOL_RE_PART}|{_CURRENCY_CODE_RE_PART})\s*"
     rf"(?P<num>{_PT_NUMBER_PTN}))(?!\d)",
     re.IGNORECASE | re.UNICODE,
 )

--- a/lexnlp/extract/pt/money.py
+++ b/lexnlp/extract/pt/money.py
@@ -110,7 +110,7 @@ def get_money_annotations(
             continue
         seen_spans.add(span)
         amount = _parse_pt_number(match.group("num"))
-        if float_digits:
+        if float_digits is not None:
             amount = round(amount, float_digits)
         yield MoneyAnnotation(
             coords=span,
@@ -121,11 +121,14 @@ def get_money_annotations(
         )
     for match in _MONEY_SUFFIX_RE.finditer(text):
         span = match.span("text")
-        if any(s <= span[0] and span[1] <= e for s, e in seen_spans):
-            # Suffix form would double-count an already-yielded prefix match.
+        # Skip a suffix match whose span overlaps any already-yielded
+        # prefix match. ``R$ 100 reais`` would otherwise yield two
+        # annotations: prefix (``R$ 100``) and suffix (``100 reais``)
+        # — overlapping but neither contains the other.
+        if any(not (span[1] <= s or e <= span[0]) for s, e in seen_spans):
             continue
         amount = _parse_pt_number(match.group("num"))
-        if float_digits:
+        if float_digits is not None:
             amount = round(amount, float_digits)
         yield MoneyAnnotation(
             coords=span,

--- a/lexnlp/extract/pt/money.py
+++ b/lexnlp/extract/pt/money.py
@@ -1,0 +1,168 @@
+"""Money extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.de.money` and :mod:`lexnlp.extract.en.money`,
+tuned to the Brazilian Real and to Brazilian numeric formatting (``.`` as
+thousands separator, ``,`` as the decimal mark). Recognises:
+
+- ``R$ 1.234,56`` / ``R$1.234,56`` — Brazilian Real with the
+  ``R$`` prefix (with or without a thin space).
+- ``1.234,56 reais`` — Real-suffixed amounts (``real`` / ``reais``).
+- ``1.234,56 BRL`` / ``BRL 1.234,56`` — ISO-4217 prefix or suffix.
+- ``USD 100,00`` / ``EUR 100,00`` / ``GBP 100,00`` — common foreign
+  currencies in Brazilian contracts (with both pre/post placement).
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import regex as re
+
+from lexnlp.extract.common.annotations.money_annotation import MoneyAnnotation
+
+# Brazilian Real and common foreign currencies seen in Brazilian contracts.
+_CURRENCY_SYMBOL_TO_CODE: dict[str, str] = {
+    "r$": "BRL",
+    "us$": "USD",
+    "$": "USD",
+    "€": "EUR",
+    "£": "GBP",
+    "¥": "JPY",
+}
+
+_CURRENCY_NAME_TO_CODE: dict[str, str] = {
+    "real": "BRL",
+    "reais": "BRL",
+    "dólar": "USD",
+    "dolar": "USD",
+    "dólares": "USD",
+    "dolares": "USD",
+    "euro": "EUR",
+    "euros": "EUR",
+    "libra": "GBP",
+    "libras": "GBP",
+    "iene": "JPY",
+    "ienes": "JPY",
+    "yen": "JPY",
+    "iuan": "CNY",
+    "yuan": "CNY",
+}
+
+_CURRENCY_CODE_RE_PART = "|".join(sorted({"BRL", "USD", "EUR", "GBP", "JPY", "CNY"}))
+_CURRENCY_NAME_RE_PART = "|".join(
+    sorted(_CURRENCY_NAME_TO_CODE.keys(), key=len, reverse=True)
+)
+_CURRENCY_SYMBOL_RE_PART = "R\\$|US\\$|\\$|€|£|¥"
+
+# Brazilian numeric pattern: optional thousands "." groups, optional decimal ","
+# fraction (e.g. "1.234,56" / "12,5" / "100").
+_PT_NUMBER_PTN = r"\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?"
+
+# Symbol/code prefix: "R$ 100,00", "USD 1.234,56".
+_MONEY_PREFIX_RE = re.compile(
+    rf"(?P<text>(?P<currency>{_CURRENCY_SYMBOL_RE_PART}|{_CURRENCY_CODE_RE_PART})\s*"
+    rf"(?P<num>{_PT_NUMBER_PTN}))(?!\d)",
+    re.IGNORECASE | re.UNICODE,
+)
+# Suffix form: "100,00 reais", "1.234,56 BRL".
+_MONEY_SUFFIX_RE = re.compile(
+    rf"(?<!\w)(?P<text>(?P<num>{_PT_NUMBER_PTN})\s+"
+    rf"(?P<currency>{_CURRENCY_NAME_RE_PART}|{_CURRENCY_CODE_RE_PART}))",
+    re.IGNORECASE | re.UNICODE,
+)
+
+
+def _parse_pt_number(raw: str) -> Decimal:
+    """Convert a Brazilian-formatted numeric string to :class:`Decimal`."""
+    return Decimal(raw.replace(".", "").replace(",", "."))
+
+
+def _normalize_currency(token: str) -> str:
+    """Map a currency symbol/name/code to its ISO 4217 code."""
+    lowered = token.lower()
+    if lowered in _CURRENCY_SYMBOL_TO_CODE:
+        return _CURRENCY_SYMBOL_TO_CODE[lowered]
+    if lowered in _CURRENCY_NAME_TO_CODE:
+        return _CURRENCY_NAME_TO_CODE[lowered]
+    return token.upper()
+
+
+def get_money_annotations(
+    text: str, float_digits: int = 4
+) -> Iterator[MoneyAnnotation]:
+    """Yield :class:`MoneyAnnotation` for every monetary expression in *text*.
+
+    Order: prefix-form matches first (``R$ 100``), then suffix-form
+    (``100 reais``). Spans returned as ``(start, end)`` of the full
+    surface text including the currency token.
+    """
+    seen_spans: set[tuple[int, int]] = set()
+    for match in _MONEY_PREFIX_RE.finditer(text):
+        span = match.span("text")
+        if span in seen_spans:
+            continue
+        seen_spans.add(span)
+        amount = _parse_pt_number(match.group("num"))
+        if float_digits:
+            amount = round(amount, float_digits)
+        yield MoneyAnnotation(
+            coords=span,
+            text=match.group("text"),
+            amount=amount,
+            currency=_normalize_currency(match.group("currency")),
+            locale="pt",
+        )
+    for match in _MONEY_SUFFIX_RE.finditer(text):
+        span = match.span("text")
+        if any(s <= span[0] and span[1] <= e for s, e in seen_spans):
+            # Suffix form would double-count an already-yielded prefix match.
+            continue
+        amount = _parse_pt_number(match.group("num"))
+        if float_digits:
+            amount = round(amount, float_digits)
+        yield MoneyAnnotation(
+            coords=span,
+            text=match.group("text"),
+            amount=amount,
+            currency=_normalize_currency(match.group("currency")),
+            locale="pt",
+        )
+
+
+def get_money(text: str, float_digits: int = 4) -> Iterator[dict]:
+    """Yield dictionaries describing each monetary expression in *text*."""
+    for ant in get_money_annotations(text, float_digits):
+        yield {
+            "location_start": ant.coords[0],
+            "location_end": ant.coords[1],
+            "source_text": ant.text,
+            "amount": ant.amount,
+            "currency": ant.currency,
+        }
+
+
+def get_money_annotation_list(
+    text: str, float_digits: int = 4
+) -> list[MoneyAnnotation]:
+    """Return all money annotations in *text* as a list."""
+    return list(get_money_annotations(text, float_digits))
+
+
+def get_money_list(text: str, float_digits: int = 4) -> list[dict]:
+    """Return all money annotations as a list of plain dictionaries."""
+    return list(get_money(text, float_digits))
+
+
+__all__ = [
+    "get_money",
+    "get_money_annotation_list",
+    "get_money_annotations",
+    "get_money_list",
+]

--- a/lexnlp/extract/pt/percents.py
+++ b/lexnlp/extract/pt/percents.py
@@ -1,0 +1,94 @@
+"""Percent extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.de.percents` and :mod:`lexnlp.extract.en.percents`
+but tuned to Brazilian number formatting (``.`` as thousands separator,
+``,`` as the decimal mark) and to the Portuguese-specific lexicon
+(``por cento`` / ``%``).
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import regex as re
+
+from lexnlp.extract.common.annotations.percent_annotation import PercentAnnotation
+
+# Brazilian numeric pattern: optional thousands "." groups, optional decimal ","
+# fraction (e.g. "1.234,56" / "12,5" / "100"). Plain integers are also matched.
+_PT_NUMBER_PTN = r"(?P<num>\d{1,3}(?:\.\d{3})*(?:,\d+)?|\d+(?:,\d+)?)"
+
+# Surface forms: "12,5%", "12.5 %", "doze por cento" (left out — see notes),
+# "12,5 por cento". We also accept the abbreviation "p.c." commonly used in
+# Brazilian financial reports.
+PERCENT_PTN_RE = re.compile(
+    rf"(?P<text>{_PT_NUMBER_PTN}\s*(?P<unit>%|por\s+cento|p\.c\.))(?:\W|$)",
+    re.IGNORECASE | re.UNICODE,
+)
+
+
+def _parse_pt_number(raw: str) -> Decimal:
+    """Convert a Brazilian-formatted numeric string to :class:`Decimal`."""
+    return Decimal(raw.replace(".", "").replace(",", "."))
+
+
+def get_percent_annotations(
+    text: str, float_digits: int = 4
+) -> Iterator[PercentAnnotation]:
+    """Yield :class:`PercentAnnotation` for every percent expression in *text*."""
+    for match in PERCENT_PTN_RE.finditer(text):
+        amount = _parse_pt_number(match.group("num"))
+        unit = match.group("unit")
+        sign = "%" if unit == "%" else "por cento"
+        fraction = amount * Decimal("0.01")
+        if float_digits:
+            fraction = round(fraction, float_digits)
+        yield PercentAnnotation(
+            coords=match.span("text"),
+            text=match.group("text"),
+            sign=sign,
+            amount=amount,
+            fraction=fraction,
+            locale="pt",
+        )
+
+
+def get_percents(text: str, float_digits: int = 4) -> Iterator[dict]:
+    """Yield dictionaries describing each percent expression in *text*."""
+    for ant in get_percent_annotations(text, float_digits):
+        yield {
+            "location_start": ant.coords[0],
+            "location_end": ant.coords[1],
+            "source_text": ant.text,
+            "unit_name": ant.sign,
+            "amount": ant.amount,
+            "real_amount": ant.fraction,
+        }
+
+
+def get_percent_annotation_list(
+    text: str, float_digits: int = 4
+) -> list[PercentAnnotation]:
+    """Return all percent annotations in *text* as a list."""
+    return list(get_percent_annotations(text, float_digits))
+
+
+def get_percent_list(text: str, float_digits: int = 4) -> list[dict]:
+    """Return all percent annotations as a list of plain dictionaries."""
+    return list(get_percents(text, float_digits))
+
+
+__all__ = [
+    "PERCENT_PTN_RE",
+    "get_percent_annotation_list",
+    "get_percent_annotations",
+    "get_percent_list",
+    "get_percents",
+]

--- a/lexnlp/extract/pt/percents.py
+++ b/lexnlp/extract/pt/percents.py
@@ -48,7 +48,7 @@ def get_percent_annotations(
         unit = match.group("unit")
         sign = "%" if unit == "%" else "por cento"
         fraction = amount * Decimal("0.01")
-        if float_digits:
+        if float_digits is not None:
             fraction = round(fraction, float_digits)
         yield PercentAnnotation(
             coords=match.span("text"),

--- a/lexnlp/extract/pt/pii.py
+++ b/lexnlp/extract/pt/pii.py
@@ -28,25 +28,40 @@ import regex as re
 from lexnlp.extract.common.annotations.phone_annotation import PhoneAnnotation
 
 # Brazilian phone number formats:
-#   ``+55 11 91234-5678`` (international prefix + DDD + mobile 9-digit)
-#   ``(11) 91234-5678``    (DDD in parens + 9-digit mobile)
-#   ``11 1234-5678``       (DDD + 8-digit landline)
-#   ``0800 123 4567``      (toll-free)
-# We accept variable separators (space, dot, hyphen) between the DDD and
-# the body. ``9`` as the leading mobile digit is optional so legacy
-# 8-digit numbers (residential) still match.
+#   ``+55 11 91234-5678``   (international prefix + DDD + 9-digit mobile)
+#   ``(11) 91234-5678``      (DDD in parens + 9-digit mobile)
+#   ``11 1234-5678``         (DDD + 8-digit landline)
+#   ``(0XX11) 1234-5678``    (legacy operator-selection placeholder
+#                            from the late-1990s telecom deregulation)
+#   ``0 32 11 1234-5678``    (legacy operator-selection with explicit
+#                            carrier code, e.g. 32 = Embratel)
+#   ``1234-5678``            (legacy 8-digit local without DDD,
+#                            requires an explicit dash to keep false
+#                            positives in check)
+#   ``234-5678``             (legacy 7-digit local without DDD,
+#                            also dash-anchored)
+#   ``0800 123 4567``        (toll-free)
 PHONE_PTN_RE = re.compile(
-    r"(?<!\d)"
+    r"(?<![\d-])"
     r"(?P<phone>"
-    r"(?:\+?55[\s.-]?)?"  # optional country code
-    r"(?:\(0?\d{2}\)|0?\d{2})"  # DDD with or without parens
+    # Format 1: full DDD form. Allows the optional ``+55`` country code
+    # OR a legacy ``0XX`` / ``0<digits>`` operator-selection prefix.
+    r"(?:\+?55[\s.-]?|0(?:[Xx]{2}|\d{2,3})[\s.-]?)?"
+    # DDD: with parens (optionally embedding the operator prefix, e.g.
+    # ``(0XX11)``) or bare two digits (with optional leading 0).
+    r"(?:\(\s*(?:0(?:[Xx]{2}|\d{2,3}))?\s*0?\d{2}\s*\)|0?\d{2})"
     r"[\s.-]?"
-    r"9?\d{4}"  # 8- or 9-digit body, leading "9" optional
+    r"9?\d{4}"  # 8- or 9-digit body, leading ``9`` optional
     r"[\s.-]?"
     r"\d{4}"
-    r"|0800[\s.-]?\d{3}[\s.-]?\d{3,4}"  # 0800 toll-free
+    # Format 2: 0800 toll-free.
+    r"|0800[\s.-]?\d{3}[\s.-]?\d{3,4}"
+    # Format 3: legacy 8-digit local without DDD (mandatory dash).
+    r"|\d{4}-\d{4}"
+    # Format 4: legacy 7-digit local without DDD (mandatory dash).
+    r"|\d{3}-\d{4}"
     r")"
-    r"(?!\d)"
+    r"(?![\d-])"
 )
 
 # Pragmatic email regex — matches the vast majority of legitimate
@@ -74,7 +89,14 @@ def get_phone_annotations(text: str) -> Iterator[PhoneAnnotation]:
     for match in PHONE_PTN_RE.finditer(text):
         surface = match.group("phone")
         digits = _digits_only(surface)
-        if len(digits) not in (10, 11, 12, 13):
+        # Accepted lengths cover (in order):
+        #   7  -> legacy 7-digit local (NNN-NNNN);
+        #   8  -> legacy 8-digit local (NNNN-NNNN) and post-2002 landline;
+        #   10 -> DDD + 8-digit landline;
+        #   11 -> DDD + 9-digit mobile;
+        #   12 -> 55 + DDD + 8 digits OR operator-prefix 0NN + DDD + 8;
+        #   13 -> 55 + DDD + 9 digits OR operator-prefix 0NN + DDD + 9.
+        if len(digits) not in (7, 8, 10, 11, 12, 13):
             continue
         yield PhoneAnnotation(
             coords=match.span("phone"),

--- a/lexnlp/extract/pt/pii.py
+++ b/lexnlp/extract/pt/pii.py
@@ -1,0 +1,135 @@
+"""PII extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.pii`, scoped to the PII surface that
+applies in Brazilian contracts:
+
+- Brazilian phone numbers — landline ``(11) 1234-5678`` and mobile
+  ``(11) 91234-5678`` formats, optional international prefix ``+55``,
+  optional area-code parentheses, optional dash separator.
+- Email addresses — same syntax everywhere; we re-export the canonical
+  RFC-5321 style regex from :mod:`lexnlp.extract.common`.
+
+CPF and CNPJ are already covered by :mod:`lexnlp.extract.pt.identifiers`,
+so this module deliberately omits them to avoid duplicate annotations.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+
+import regex as re
+
+from lexnlp.extract.common.annotations.phone_annotation import PhoneAnnotation
+
+# Brazilian phone number formats:
+#   ``+55 11 91234-5678`` (international prefix + DDD + mobile 9-digit)
+#   ``(11) 91234-5678``    (DDD in parens + 9-digit mobile)
+#   ``11 1234-5678``       (DDD + 8-digit landline)
+#   ``0800 123 4567``      (toll-free)
+# We accept variable separators (space, dot, hyphen) between the DDD and
+# the body. ``9`` as the leading mobile digit is optional so legacy
+# 8-digit numbers (residential) still match.
+PHONE_PTN_RE = re.compile(
+    r"(?<!\d)"
+    r"(?P<phone>"
+    r"(?:\+?55[\s.-]?)?"  # optional country code
+    r"(?:\(0?\d{2}\)|0?\d{2})"  # DDD with or without parens
+    r"[\s.-]?"
+    r"9?\d{4}"  # 8- or 9-digit body, leading "9" optional
+    r"[\s.-]?"
+    r"\d{4}"
+    r"|0800[\s.-]?\d{3}[\s.-]?\d{3,4}"  # 0800 toll-free
+    r")"
+    r"(?!\d)"
+)
+
+# Pragmatic email regex — matches the vast majority of legitimate
+# addresses without trying to fully cover RFC 5321.
+EMAIL_PTN_RE = re.compile(
+    r"(?<![\w.+-])"
+    r"(?P<email>[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})"
+    r"(?![\w.])"
+)
+
+
+def _digits_only(value: str) -> str:
+    """Strip every non-digit character (including ``+``)."""
+    return re.sub(r"\D", "", value)
+
+
+def get_phone_annotations(text: str) -> Iterator[PhoneAnnotation]:
+    """Yield :class:`PhoneAnnotation` for every Brazilian phone number.
+
+    The ``phone`` field is the canonical digits-only form (without the
+    ``+``); the ``text`` field preserves the original surface (with
+    whatever separators the source used). Numbers shorter than 10 digits
+    or longer than 13 are rejected as false positives.
+    """
+    for match in PHONE_PTN_RE.finditer(text):
+        surface = match.group("phone")
+        digits = _digits_only(surface)
+        if len(digits) not in (10, 11, 12, 13):
+            continue
+        yield PhoneAnnotation(
+            coords=match.span("phone"),
+            phone=digits,
+            text=surface,
+            locale="pt",
+        )
+
+
+def get_phones(text: str) -> Iterator[str]:
+    """Yield the canonical digits-only phone for every match in *text*."""
+    for ant in get_phone_annotations(text):
+        yield ant.phone
+
+
+def get_phone_list(text: str) -> list[str]:
+    """Return all canonical phone strings in *text* as a list."""
+    return list(get_phones(text))
+
+
+def get_phone_annotation_list(text: str) -> list[PhoneAnnotation]:
+    """Return all phone annotations in *text* as a list."""
+    return list(get_phone_annotations(text))
+
+
+def get_emails(text: str) -> Iterator[str]:
+    """Yield every email address found in *text*."""
+    for match in EMAIL_PTN_RE.finditer(text):
+        yield match.group("email")
+
+
+def get_email_list(text: str) -> list[str]:
+    """Return all email addresses in *text* as a list."""
+    return list(get_emails(text))
+
+
+def get_pii_annotations(text: str) -> Iterator[PhoneAnnotation]:
+    """Yield phone PII annotations for *text*.
+
+    Email addresses are surfaced via :func:`get_emails` (no dedicated
+    annotation class exists in lexnlp/common). Callers that want both
+    streams can iterate ``get_phone_annotations`` and ``get_emails``
+    side-by-side.
+    """
+    yield from get_phone_annotations(text)
+
+
+__all__ = [
+    "EMAIL_PTN_RE",
+    "PHONE_PTN_RE",
+    "get_email_list",
+    "get_emails",
+    "get_phone_annotation_list",
+    "get_phone_annotations",
+    "get_phone_list",
+    "get_phones",
+    "get_pii_annotations",
+]

--- a/lexnlp/extract/pt/ratios.py
+++ b/lexnlp/extract/pt/ratios.py
@@ -1,9 +1,11 @@
 """Ratio extraction for Portuguese (pt-BR).
 
 Mirrors :mod:`lexnlp.extract.en.ratios`, swapping in the canonical pt-BR
-number pattern and accepting Brazilian connector words ``para`` /
-``por`` (``três para um``, ``2 por 1``) alongside the universal ``:`` /
-``/`` / ``-`` separators (``3:1``, ``3/1``, ``3-1``).
+number pattern. The pattern (:data:`RATIO_PTN_RE`) accepts the Brazilian
+connector words ``para`` / ``por`` and the universal separators ``:`` /
+``/`` / ``-`` between **numeric** operands (``2 para 1``, ``2 por 1``,
+``3:1``, ``3/1``, ``3-1``). Word-form numbers (e.g. ``três para um``)
+are NOT matched: only :data:`NUM_PTN`-shaped digit forms are accepted.
 """
 
 __author__ = "ContraxSuite, LLC; LexPredict, LLC"

--- a/lexnlp/extract/pt/ratios.py
+++ b/lexnlp/extract/pt/ratios.py
@@ -1,0 +1,94 @@
+"""Ratio extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.ratios`, swapping in the canonical pt-BR
+number pattern and accepting Brazilian connector words ``para`` /
+``por`` (``três para um``, ``2 por 1``) alongside the universal ``:`` /
+``/`` / ``-`` separators (``3:1``, ``3/1``, ``3-1``).
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import regex as re
+
+from lexnlp.extract.common.annotations.ratio_annotation import RatioAnnotation
+from lexnlp.extract.pt.amounts import NUM_PTN, _parse_pt_number  # noqa: PLC2701 - reuse pt number parser
+
+RATIO_PTN_RE = re.compile(
+    rf"(?P<text>(?P<left>{NUM_PTN})\s*"
+    rf"(?:para|por|:|/|-)\s*"
+    rf"(?P<right>{NUM_PTN}))(?!\s*[ap]\.?m(?:\W|$))",
+    re.IGNORECASE | re.MULTILINE | re.UNICODE,
+)
+
+
+def get_ratio_annotations(
+    text: str, float_digits: int = 4
+) -> Iterator[RatioAnnotation]:
+    """Yield :class:`RatioAnnotation` for every ratio expression in *text*.
+
+    The ratio is computed as ``left / right`` and stored alongside the
+    individual operands. Matches followed by a time-of-day suffix
+    (``a.m.`` / ``p.m.``) are ignored to avoid false positives on clock
+    expressions.
+    """
+    for match in RATIO_PTN_RE.finditer(text):
+        left = _parse_pt_number(match.group("left"))
+        right = _parse_pt_number(match.group("right"))
+        if right == 0:
+            continue
+        ratio = left / right
+        if float_digits:
+            left = round(left, float_digits)
+            right = round(right, float_digits)
+            ratio = round(ratio, float_digits)
+        yield RatioAnnotation(
+            coords=match.span("text"),
+            text=match.group("text"),
+            left=left,
+            right=right,
+            ratio=ratio,
+            locale="pt",
+        )
+
+
+def get_ratios(
+    text: str, return_sources: bool = False, float_digits: int = 4
+) -> Iterator[tuple[Decimal, Decimal, Decimal] | tuple[Decimal, Decimal, Decimal, str]]:
+    """Yield ``(left, right, ratio)`` tuples (optionally with source text)."""
+    for ant in get_ratio_annotations(text, float_digits=float_digits):
+        if return_sources:
+            yield ant.left, ant.right, ant.ratio, ant.text
+        else:
+            yield ant.left, ant.right, ant.ratio
+
+
+def get_ratio_annotation_list(
+    text: str, float_digits: int = 4
+) -> list[RatioAnnotation]:
+    """Return all ratio annotations in *text* as a list."""
+    return list(get_ratio_annotations(text, float_digits))
+
+
+def get_ratio_list(
+    text: str, return_sources: bool = False, float_digits: int = 4
+) -> list[tuple[Decimal, Decimal, Decimal] | tuple[Decimal, Decimal, Decimal, str]]:
+    """Return all ratio tuples in *text* as a list."""
+    return list(get_ratios(text, return_sources, float_digits))
+
+
+__all__ = [
+    "RATIO_PTN_RE",
+    "get_ratio_annotation_list",
+    "get_ratio_annotations",
+    "get_ratio_list",
+    "get_ratios",
+]

--- a/lexnlp/extract/pt/tests/test_amounts.py
+++ b/lexnlp/extract/pt/tests/test_amounts.py
@@ -85,6 +85,17 @@ class TestTextToNumber(TestCase):
         self.assertEqual(Decimal(16), text_to_number("dezasseis"))
         self.assertEqual(Decimal(19), text_to_number("dezanove"))
 
+    def test_pre_acordo_ortografico_cinquenta(self):
+        """``cinqüenta`` (with trema) is the pre-1990-Acordo spelling."""
+        self.assertEqual(Decimal(50), text_to_number("cinqüenta"))
+        # Combined with units it still composes correctly.
+        self.assertEqual(Decimal(57), text_to_number("cinqüenta e sete"))
+        # Inside a larger phrase.
+        self.assertEqual(
+            Decimal(2_350_000),
+            text_to_number("dois milhões trezentos e cinqüenta mil"),
+        )
+
 
 class TestGetAmountAnnotations(TestCase):
     def test_extracts_numeric_with_multiplier(self):

--- a/lexnlp/extract/pt/tests/test_amounts.py
+++ b/lexnlp/extract/pt/tests/test_amounts.py
@@ -73,6 +73,18 @@ class TestTextToNumber(TestCase):
         # "um milhão e meio" should resolve to 1,500,000
         self.assertEqual(Decimal("1500000"), text_to_number("um milhão e meio"))
 
+    def test_leading_fraction_with_multiplier(self):
+        """``meio milhão`` / ``meia bilhão`` should consume the trailing
+        multiplier rather than apply ``last_mult`` (which is 1 by default).
+        """
+        self.assertEqual(Decimal(500_000), text_to_number("meio milhão"))
+        self.assertEqual(Decimal(500_000_000), text_to_number("meio bilhão"))
+        self.assertEqual(Decimal(500_000_000), text_to_number("meia bilhão"))
+
+    def test_bare_fraction_returns_half(self):
+        """``meio`` alone (no following multiplier) is just 0.5."""
+        self.assertEqual(Decimal("0.5"), text_to_number("meio"))
+
     def test_unknown_token_returns_none(self):
         self.assertIsNone(text_to_number("xyzabc não é número"))
 

--- a/lexnlp/extract/pt/tests/test_amounts.py
+++ b/lexnlp/extract/pt/tests/test_amounts.py
@@ -1,0 +1,113 @@
+"""Tests for :mod:`lexnlp.extract.pt.amounts`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.amounts import (
+    get_amount_annotation_list,
+    text_to_number,
+)
+
+
+class TestTextToNumber(TestCase):
+    def test_units(self):
+        self.assertEqual(Decimal(1), text_to_number("um"))
+        self.assertEqual(Decimal(2), text_to_number("dois"))
+        self.assertEqual(Decimal(2), text_to_number("duas"))
+        self.assertEqual(Decimal(9), text_to_number("nove"))
+
+    def test_teens(self):
+        self.assertEqual(Decimal(11), text_to_number("onze"))
+        self.assertEqual(Decimal(15), text_to_number("quinze"))
+        self.assertEqual(Decimal(19), text_to_number("dezenove"))
+
+    def test_tens_and_units(self):
+        self.assertEqual(Decimal(21), text_to_number("vinte e um"))
+        self.assertEqual(Decimal(99), text_to_number("noventa e nove"))
+
+    def test_hundreds(self):
+        self.assertEqual(Decimal(100), text_to_number("cem"))
+        self.assertEqual(Decimal(125), text_to_number("cento e vinte e cinco"))
+        self.assertEqual(Decimal(500), text_to_number("quinhentos"))
+
+    def test_thousands(self):
+        self.assertEqual(Decimal(1000), text_to_number("mil"))
+        self.assertEqual(Decimal(1250), text_to_number("mil duzentos e cinquenta"))
+        self.assertEqual(Decimal(2500), text_to_number("dois mil e quinhentos"))
+        self.assertEqual(
+            Decimal(5430), text_to_number("cinco mil quatrocentos e trinta")
+        )
+
+    def test_millions(self):
+        self.assertEqual(Decimal(1_000_000), text_to_number("um milhão"))
+        self.assertEqual(Decimal(3_000_000), text_to_number("três milhões"))
+        self.assertEqual(
+            Decimal(1_250_000),
+            text_to_number("um milhão duzentos e cinquenta mil"),
+        )
+
+    def test_billions(self):
+        self.assertEqual(Decimal(1_000_000_000), text_to_number("um bilhão"))
+        self.assertEqual(Decimal(2_500_000_000), text_to_number("dois bilhões e quinhentos milhões"))
+
+    def test_trillions(self):
+        self.assertEqual(Decimal(1_000_000_000_000), text_to_number("um trilhão"))
+        self.assertEqual(
+            Decimal(1_500_000_000_000),
+            text_to_number("um trilhão e quinhentos bilhões"),
+        )
+        self.assertEqual(
+            Decimal(7_000_000_000_000),
+            text_to_number("sete trilhões"),
+        )
+
+    def test_meio_after_multiplier(self):
+        # "um milhão e meio" should resolve to 1,500,000
+        self.assertEqual(Decimal("1500000"), text_to_number("um milhão e meio"))
+
+    def test_unknown_token_returns_none(self):
+        self.assertIsNone(text_to_number("xyzabc não é número"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(text_to_number(""))
+        self.assertIsNone(text_to_number(None))
+
+    def test_pt_pt_spellings(self):
+        # pt-PT spellings ("dezasseis", "dezassete", "dezanove") accepted.
+        self.assertEqual(Decimal(16), text_to_number("dezasseis"))
+        self.assertEqual(Decimal(19), text_to_number("dezanove"))
+
+
+class TestGetAmountAnnotations(TestCase):
+    def test_extracts_numeric_with_multiplier(self):
+        text = "O fundo soma 2,5 milhões de reais."
+        ants = get_amount_annotation_list(text)
+        self.assertGreaterEqual(len(ants), 1)
+        # First should be the "2,5 milhões" combined match.
+        self.assertEqual(Decimal("2500000"), ants[0].value)
+
+    def test_extracts_word_amount(self):
+        text = "Foram aplicados cento e vinte e cinco testes."
+        ants = get_amount_annotation_list(text)
+        # Pure word match for "cento e vinte e cinco" = 125
+        values = [a.value for a in ants]
+        self.assertIn(Decimal(125), values)
+
+    def test_extracts_plain_numeric(self):
+        text = "Total: 1.234,56 unidades."
+        ants = get_amount_annotation_list(text)
+        self.assertGreaterEqual(len(ants), 1)
+        values = [a.value for a in ants]
+        self.assertIn(Decimal("1234.56"), values)
+
+    def test_locale_is_pt(self):
+        ants = get_amount_annotation_list("100 dias")
+        self.assertTrue(all(a.locale == "pt" for a in ants))

--- a/lexnlp/extract/pt/tests/test_amounts.py
+++ b/lexnlp/extract/pt/tests/test_amounts.py
@@ -76,10 +76,15 @@ class TestTextToNumber(TestCase):
     def test_leading_fraction_with_multiplier(self):
         """``meio milhão`` / ``meia bilhão`` should consume the trailing
         multiplier rather than apply ``last_mult`` (which is 1 by default).
+        Mixed ``um e meio milhão`` must combine the whole part with the
+        fraction before multiplying.
         """
         self.assertEqual(Decimal(500_000), text_to_number("meio milhão"))
         self.assertEqual(Decimal(500_000_000), text_to_number("meio bilhão"))
         self.assertEqual(Decimal(500_000_000), text_to_number("meia bilhão"))
+        # Whole + fraction + multiplier composition.
+        self.assertEqual(Decimal(1_500_000), text_to_number("um e meio milhão"))
+        self.assertEqual(Decimal(2_500_000_000), text_to_number("dois e meio bilhão"))
 
     def test_bare_fraction_returns_half(self):
         """``meio`` alone (no following multiplier) is just 0.5."""

--- a/lexnlp/extract/pt/tests/test_citations.py
+++ b/lexnlp/extract/pt/tests/test_citations.py
@@ -86,8 +86,12 @@ class TestCnjProcessNumbers(TestCase):
 class TestGetCitationAnnotations(TestCase):
     def test_combined_stream(self):
         text = "REsp 1.000/SP combinado com 9876543-21.2019.8.26.0100."
+        # Each subtype must produce exactly one annotation — guards
+        # against the aggregate test passing while one subtype regresses
+        # to zero matches.
+        self.assertEqual(1, len(list(get_case_citation_annotations(text))))
+        self.assertEqual(1, len(list(get_cnj_process_annotations(text))))
         ants = get_citation_annotation_list(text)
-        # One short-form + one CNJ-format = 2 annotations.
         self.assertEqual(2, len(ants))
 
     def test_no_match_in_plain_text(self):

--- a/lexnlp/extract/pt/tests/test_citations.py
+++ b/lexnlp/extract/pt/tests/test_citations.py
@@ -58,6 +58,13 @@ class TestBrazilianCaseCitations(TestCase):
         self.assertEqual(1, len(ants))
         self.assertEqual(1985, ants[0].year)
 
+    def test_ungrouped_4_digit_number(self):
+        """``MS 12345`` / ``CC 99999`` (no thousands dot) must match."""
+        text = "Vide MS 12345 e CC 99999/SP do tribunal."
+        ants = list(get_case_citation_annotations(text))
+        reporters = sorted(a.reporter for a in ants)
+        self.assertEqual(["CC", "MS"], reporters)
+
 
 class TestCnjProcessNumbers(TestCase):
     def test_extracts_full_cnj_format(self):

--- a/lexnlp/extract/pt/tests/test_citations.py
+++ b/lexnlp/extract/pt/tests/test_citations.py
@@ -1,0 +1,87 @@
+"""Tests for :mod:`lexnlp.extract.pt.citations`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.pt.citations import (
+    get_case_citation_annotations,
+    get_citation_annotation_list,
+    get_cnj_process_annotations,
+)
+
+
+class TestBrazilianCaseCitations(TestCase):
+    def test_extracts_resp_with_uf(self):
+        text = "Vide o REsp 12.345/SP julgado em 2020."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        ant = ants[0]
+        self.assertEqual("REsp", ant.reporter)
+        self.assertEqual("SP", ant.court)
+        self.assertEqual("pt", ant.locale)
+
+    def test_extracts_re(self):
+        text = "Conforme o RE 123.456 do STF."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        self.assertEqual("RE", ants[0].reporter)
+        self.assertEqual(123456, ants[0].volume)
+
+    def test_extracts_adi(self):
+        text = "A ADI 1.234 foi julgada procedente."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        self.assertEqual("ADI", ants[0].reporter)
+
+    def test_extracts_agrg_no_aresp(self):
+        text = "Posteriormente, AgRg no AREsp 234.567/RS confirmou o entendimento."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        self.assertEqual("AgRg no AREsp", ants[0].reporter)
+
+    def test_extracts_hc(self):
+        text = "Concedido o HC 99.999 em decisão monocrática."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        self.assertEqual("HC", ants[0].reporter)
+
+    def test_year_normalisation(self):
+        text = "Conforme RE 123/85 do plenário."
+        ants = list(get_case_citation_annotations(text))
+        self.assertEqual(1, len(ants))
+        self.assertEqual(1985, ants[0].year)
+
+
+class TestCnjProcessNumbers(TestCase):
+    def test_extracts_full_cnj_format(self):
+        text = "O processo 1234567-89.2020.5.04.0001 foi distribuído."
+        ants = list(get_cnj_process_annotations(text))
+        self.assertEqual(1, len(ants))
+        ant = ants[0]
+        self.assertEqual(2020, ant.year)
+        self.assertIn("seg=5", ant.volume_str)
+        self.assertIn("tr=04", ant.volume_str)
+        self.assertIn("orig=0001", ant.volume_str)
+        self.assertEqual("pt", ant.locale)
+
+    def test_no_match_for_partial_format(self):
+        text = "Número parcial 1234567-89."
+        self.assertEqual([], list(get_cnj_process_annotations(text)))
+
+
+class TestGetCitationAnnotations(TestCase):
+    def test_combined_stream(self):
+        text = "REsp 1.000/SP combinado com 9876543-21.2019.8.26.0100."
+        ants = get_citation_annotation_list(text)
+        # One short-form + one CNJ-format = 2 annotations.
+        self.assertEqual(2, len(ants))
+
+    def test_no_match_in_plain_text(self):
+        self.assertEqual([], get_citation_annotation_list("Sem citações aqui."))

--- a/lexnlp/extract/pt/tests/test_definitions.py
+++ b/lexnlp/extract/pt/tests/test_definitions.py
@@ -10,6 +10,7 @@ from unittest import TestCase
 
 from lexnlp.extract.common.annotations.definition_annotation import DefinitionAnnotation
 from lexnlp.extract.pt.definitions import (
+    PortugueseParsingMethods,
     get_definition_annotation_list,
     get_definition_annotations,
     make_pt_definitions_parser,
@@ -77,3 +78,39 @@ class TestParsePortugueseDefinitions(TestCase):
             "lexnlp/typed_annotations/pt/definition/definitions.txt",
             DefinitionAnnotation,
         )
+
+
+class TestParenthesisedLabelMatcher(TestCase):
+    """Coverage for ``match_pt_def_by_parenthesised_label``."""
+
+    def test_single_parenthesised_label(self):
+        phrase = 'Empresa X (o "Contratante") celebra este contrato.'
+        results = PortugueseParsingMethods.match_pt_def_by_parenthesised_label(phrase)
+        self.assertEqual(1, len(results))
+        entry = results[0]
+        self.assertEqual("Contratante", entry.name)
+        self.assertEqual(85, entry.probability)
+        # span must wrap the parenthesised group
+        self.assertEqual('(o "Contratante")', phrase[entry.start:entry.end])
+
+    def test_ou_joined_alternatives_share_coords(self):
+        phrase = 'As partes (o "Locador" ou "Locatário") concordam.'
+        results = PortugueseParsingMethods.match_pt_def_by_parenthesised_label(phrase)
+        self.assertEqual(2, len(results))
+        names = sorted(r.name for r in results)
+        self.assertEqual(["Locador", "Locatário"], names)
+        # Both entries share the same surface coordinates.
+        self.assertEqual(results[0].start, results[1].start)
+        self.assertEqual(results[0].end, results[1].end)
+
+    def test_no_match(self):
+        phrase = "Sem rótulo entre parênteses aqui."
+        self.assertEqual(
+            [], PortugueseParsingMethods.match_pt_def_by_parenthesised_label(phrase)
+        )
+
+    def test_multiple_parenthesised_groups(self):
+        phrase = '(o "Comprador") e mais tarde (a "Vendedora").'
+        results = PortugueseParsingMethods.match_pt_def_by_parenthesised_label(phrase)
+        self.assertEqual(2, len(results))
+        self.assertEqual({"Comprador", "Vendedora"}, {r.name for r in results})

--- a/lexnlp/extract/pt/tests/test_distances.py
+++ b/lexnlp/extract/pt/tests/test_distances.py
@@ -1,0 +1,62 @@
+"""Tests for :mod:`lexnlp.extract.pt.distances`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.distances import (
+    get_distance_annotation_list,
+    get_distance_list,
+)
+
+
+class TestPtDistances(TestCase):
+    def test_extracts_kilometers_word(self):
+        text = "A obra cobre 12,5 quilômetros de estrada."
+        ants = get_distance_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("12.5"), ants[0].amount)
+        self.assertEqual("kilometer", ants[0].distance_type)
+        self.assertEqual("pt", ants[0].locale)
+
+    def test_extracts_km_symbol(self):
+        text = "Distância máxima: 100 km do litoral."
+        ants = get_distance_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("100"), ants[0].amount)
+        self.assertEqual("kilometer", ants[0].distance_type)
+
+    def test_extracts_metros(self):
+        text = "Recuo mínimo de 5 metros do alinhamento."
+        ants = get_distance_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("meter", ants[0].distance_type)
+
+    def test_extracts_milhas(self):
+        text = "Distância oficial de 26 milhas."
+        ants = get_distance_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("mile", ants[0].distance_type)
+
+    def test_thousands_separator(self):
+        text = "O perímetro chega a 1.234,56 metros."
+        ants = get_distance_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("1234.56"), ants[0].amount)
+
+    def test_get_distance_list_with_sources(self):
+        results = get_distance_list("100 km", return_sources=True)
+        self.assertEqual(1, len(results))
+        self.assertEqual(Decimal("100"), results[0][0])
+        self.assertEqual("kilometer", results[0][1])
+        self.assertIn("100", results[0][2])
+
+    def test_no_match_in_unrelated_text(self):
+        self.assertEqual([], get_distance_annotation_list("Sem distâncias citadas."))

--- a/lexnlp/extract/pt/tests/test_durations.py
+++ b/lexnlp/extract/pt/tests/test_durations.py
@@ -1,0 +1,72 @@
+"""Tests for :mod:`lexnlp.extract.pt.durations`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.durations import (
+    get_duration_annotation_list,
+    get_duration_annotations,
+    get_duration_list,
+)
+
+
+class TestPtDurations(TestCase):
+    def test_extracts_simple_year(self):
+        ants = get_duration_annotation_list("O contrato tem prazo de 3 anos.")
+        self.assertEqual(1, len(ants))
+        ant = ants[0]
+        self.assertEqual(Decimal("3"), ant.amount)
+        self.assertEqual("year", ant.duration_type_en)
+        self.assertEqual(Decimal(3) * Decimal(365), ant.duration_days)
+        self.assertEqual("pt", ant.locale)
+
+    def test_extracts_meses(self):
+        ants = get_duration_annotation_list("Aviso prévio de 30 dias.")
+        self.assertEqual(1, len(ants))
+        self.assertEqual("day", ants[0].duration_type_en)
+        self.assertEqual(Decimal("30"), ants[0].amount)
+
+    def test_extracts_compound_e(self):
+        """`2 anos e 6 meses` collapses into a single complex annotation."""
+        text = "Vigência de 2 anos e 6 meses, prorrogável."
+        ants = get_duration_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        ant = ants[0]
+        self.assertTrue(ant.is_complex)
+        self.assertEqual("month", ant.duration_type_en)  # last unit
+        # 2*365 + 6*30 = 730 + 180 = 910
+        self.assertEqual(Decimal("910"), ant.duration_days)
+
+    def test_separate_durations_not_grouped(self):
+        text = "Reunião em 30 dias. Pagamento em 90 dias."
+        ants = get_duration_annotation_list(text)
+        self.assertEqual(2, len(ants))
+
+    def test_prefix_captured(self):
+        text = "Aproximadamente 5 anos para conclusão."
+        ants = get_duration_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertIsNotNone(ants[0].prefix)
+
+    def test_get_duration_list_returns_dicts(self):
+        results = get_duration_list("Pagamento em 60 dias.")
+        self.assertEqual(1, len(results))
+        self.assertEqual(Decimal("60"), results[0]["amount"])
+        self.assertEqual("dias", results[0]["duration_type"])
+
+    def test_no_match_in_unrelated_text(self):
+        self.assertEqual([], list(get_duration_annotations("Sem prazo definido.")))
+
+    def test_quinzena_recognized(self):
+        ants = get_duration_annotation_list("Pagamento a cada 2 quinzenas.")
+        self.assertEqual(1, len(ants))
+        self.assertEqual("fortnight", ants[0].duration_type_en)
+        self.assertEqual(Decimal("28"), ants[0].duration_days)

--- a/lexnlp/extract/pt/tests/test_durations.py
+++ b/lexnlp/extract/pt/tests/test_durations.py
@@ -70,3 +70,20 @@ class TestPtDurations(TestCase):
         self.assertEqual(1, len(ants))
         self.assertEqual("fortnight", ants[0].duration_type_en)
         self.assertEqual(Decimal("28"), ants[0].duration_days)
+
+    def test_compound_text_preserves_separators(self):
+        """``2 anos e 6 meses`` keeps the connector ``e`` in ``text``."""
+        text = "Vigência de 2 anos e 6 meses, prorrogável."
+        ants = get_duration_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertIn("e", ants[0].text)
+        self.assertIn("anos", ants[0].text)
+        self.assertIn("meses", ants[0].text)
+
+    def test_quarter_unit_does_not_raise(self):
+        """``trimestre`` resolves through the Fraction(365, 4) ratio."""
+        ants = get_duration_annotation_list("Pagamento em 3 trimestres.")
+        self.assertEqual(1, len(ants))
+        self.assertEqual("quarter", ants[0].duration_type_en)
+        # 3 * 365/4 = 273.75
+        self.assertEqual(Decimal("273.75"), ants[0].duration_days)

--- a/lexnlp/extract/pt/tests/test_durations.py
+++ b/lexnlp/extract/pt/tests/test_durations.py
@@ -46,7 +46,10 @@ class TestPtDurations(TestCase):
         self.assertEqual(Decimal("910"), ant.duration_days)
 
     def test_separate_durations_not_grouped(self):
-        text = "Reunião em 30 dias. Pagamento em 90 dias."
+        """Sentence terminator ``.`` must break grouping even when the
+        second unit is shorter (descending pair) than the first.
+        """
+        text = "Prazo de 2 anos. Carência de 6 meses."
         ants = get_duration_annotation_list(text)
         self.assertEqual(2, len(ants))
 
@@ -72,13 +75,13 @@ class TestPtDurations(TestCase):
         self.assertEqual(Decimal("28"), ants[0].duration_days)
 
     def test_compound_text_preserves_separators(self):
-        """``2 anos e 6 meses`` keeps the connector ``e`` in ``text``."""
+        """``2 anos e 6 meses`` keeps the full surface (incl. connector ``e``)."""
         text = "Vigência de 2 anos e 6 meses, prorrogável."
         ants = get_duration_annotation_list(text)
         self.assertEqual(1, len(ants))
-        self.assertIn("e", ants[0].text)
-        self.assertIn("anos", ants[0].text)
-        self.assertIn("meses", ants[0].text)
+        # Exact match — would fail if the separator were dropped (e.g.
+        # ``2 anos6 meses``) because of an in-place text concatenation.
+        self.assertEqual("2 anos e 6 meses", ants[0].text)
 
     def test_quarter_unit_does_not_raise(self):
         """``trimestre`` resolves through the Fraction(365, 4) ratio."""

--- a/lexnlp/extract/pt/tests/test_money.py
+++ b/lexnlp/extract/pt/tests/test_money.py
@@ -1,0 +1,74 @@
+"""Tests for :mod:`lexnlp.extract.pt.money`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.money import (
+    get_money,
+    get_money_annotation_list,
+    get_money_annotations,
+)
+
+
+class TestPtMoney(TestCase):
+    def test_extracts_real_with_prefix(self):
+        text = "O valor do contrato é R$ 1.234,56."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("1234.56"), ants[0].amount)
+        self.assertEqual("BRL", ants[0].currency)
+        self.assertEqual("pt", ants[0].locale)
+
+    def test_extracts_real_no_space(self):
+        text = "Multa de R$10.000,00 será aplicada."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("10000.00"), ants[0].amount)
+        self.assertEqual("BRL", ants[0].currency)
+
+    def test_extracts_reais_suffix(self):
+        text = "O custo é de 1.500,00 reais por mês."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("1500.00"), ants[0].amount)
+        self.assertEqual("BRL", ants[0].currency)
+
+    def test_extracts_iso_code_prefix(self):
+        text = "Pagamento de USD 1.000,00 deve ser feito."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("USD", ants[0].currency)
+
+    def test_extracts_iso_code_suffix(self):
+        text = "Saldo final: 250,00 EUR ao final do contrato."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("EUR", ants[0].currency)
+
+    def test_dedupes_prefix_and_suffix(self):
+        # If a number has a "R$" prefix the suffix-form (e.g. "reais") should
+        # not yield a duplicate annotation for the same amount.
+        text = "O custo é R$ 1.500,00 reais."
+        ants = get_money_annotation_list(text)
+        # We accept either single (preferred) or two non-overlapping matches
+        # but never the same span twice.
+        spans = {a.coords for a in ants}
+        self.assertEqual(len(spans), len(ants))
+
+    def test_get_money_returns_dicts(self):
+        text = "Valor: R$ 50,00."
+        results = list(get_money(text))
+        self.assertEqual(1, len(results))
+        self.assertEqual(Decimal("50.00"), results[0]["amount"])
+        self.assertEqual("BRL", results[0]["currency"])
+
+    def test_no_money_in_plain_text(self):
+        self.assertEqual([], list(get_money_annotations("Sem valores aqui.")))

--- a/lexnlp/extract/pt/tests/test_money.py
+++ b/lexnlp/extract/pt/tests/test_money.py
@@ -72,3 +72,17 @@ class TestPtMoney(TestCase):
 
     def test_no_money_in_plain_text(self):
         self.assertEqual([], list(get_money_annotations("Sem valores aqui.")))
+
+    def test_overlapping_prefix_and_suffix_dedupe(self):
+        """``R$ 100 reais`` overlaps without containment; only one annotation."""
+        text = "Pagamento de R$ 100 reais."
+        ants = get_money_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("100"), ants[0].amount)
+
+    def test_float_digits_zero_rounds_to_integer(self):
+        text = "Valor: R$ 12,7."
+        ants = get_money_annotation_list(text, float_digits=0)
+        self.assertEqual(1, len(ants))
+        # 12.7 rounded to 0 places = 13 (banker's rounding to nearest int)
+        self.assertEqual(Decimal("13"), ants[0].amount)

--- a/lexnlp/extract/pt/tests/test_percents.py
+++ b/lexnlp/extract/pt/tests/test_percents.py
@@ -1,0 +1,60 @@
+"""Tests for :mod:`lexnlp.extract.pt.percents`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.percents import (
+    get_percent_annotation_list,
+    get_percent_annotations,
+    get_percent_list,
+)
+
+
+class TestPtPercents(TestCase):
+    def test_extracts_simple_percent_with_symbol(self):
+        text = "A taxa de juros é de 12,5% ao mês."
+        results = list(get_percent_annotations(text))
+        self.assertEqual(1, len(results))
+        ant = results[0]
+        self.assertEqual(Decimal("12.5"), ant.amount)
+        self.assertEqual(Decimal("0.125"), ant.fraction)
+        self.assertEqual("%", ant.sign)
+        self.assertEqual("pt", ant.locale)
+
+    def test_extracts_with_thousands_separator(self):
+        text = "Aplicou-se o juros de 1.234,56% sobre o valor."
+        ants = get_percent_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("1234.56"), ants[0].amount)
+
+    def test_extracts_por_cento(self):
+        text = "Aplicou-se uma alíquota de 27,5 por cento."
+        ants = get_percent_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("27.5"), ants[0].amount)
+        self.assertEqual("por cento", ants[0].sign)
+
+    def test_no_match_for_plain_number(self):
+        self.assertEqual([], get_percent_annotation_list("o valor é 100"))
+
+    def test_get_percent_list_returns_dicts(self):
+        text = "A meta é 5,5% do PIB."
+        results = get_percent_list(text)
+        self.assertEqual(1, len(results))
+        self.assertEqual(Decimal("5.5"), results[0]["amount"])
+        self.assertEqual("%", results[0]["unit_name"])
+
+    def test_extracts_multiple_percents(self):
+        text = "Em 2020, 12,5% dos contratos; em 2021, 25%."
+        ants = get_percent_annotation_list(text)
+        self.assertEqual(2, len(ants))
+        amounts = sorted(a.amount for a in ants)
+        self.assertEqual([Decimal("12.5"), Decimal("25")], amounts)

--- a/lexnlp/extract/pt/tests/test_percents.py
+++ b/lexnlp/extract/pt/tests/test_percents.py
@@ -58,3 +58,10 @@ class TestPtPercents(TestCase):
         self.assertEqual(2, len(ants))
         amounts = sorted(a.amount for a in ants)
         self.assertEqual([Decimal("12.5"), Decimal("25")], amounts)
+
+    def test_float_digits_zero_rounds(self):
+        """``float_digits=0`` is a valid rounding request, not "skip rounding"."""
+        ants = get_percent_annotation_list("12,7%", float_digits=0)
+        self.assertEqual(1, len(ants))
+        # 12.7 * 0.01 = 0.127, rounded to 0 places = 0
+        self.assertEqual(Decimal("0"), ants[0].fraction)

--- a/lexnlp/extract/pt/tests/test_pii.py
+++ b/lexnlp/extract/pt/tests/test_pii.py
@@ -50,6 +50,36 @@ class TestPtPhones(TestCase):
     def test_no_phone_in_plain_text(self):
         self.assertEqual([], get_phone_list("Sem telefones aqui."))
 
+    def test_legacy_8_digit_local_without_ddd(self):
+        """Pre-2012 8-digit landline without DDD (``1234-5678``)."""
+        text = "Telefone do escritório: 1234-5678."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("12345678", ants[0].phone)
+
+    def test_legacy_7_digit_local_without_ddd(self):
+        """Pre-2002 7-digit local number (``234-5678``)."""
+        text = "Antigo número: 234-5678."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("2345678", ants[0].phone)
+
+    def test_oxx_operator_placeholder(self):
+        """``0XX11 1234-5678`` — late-1990s telecom-deregulation prefix."""
+        text = "Ligar (0XX11) 1234-5678 a partir de outra cidade."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        # Digits captured: "0xx" -> stripped, leaving "11" + "12345678".
+        # The exact normalisation depends on the regex, but the surface
+        # form must be preserved on the annotation.
+        self.assertIn("0XX11", ants[0].text)
+
+    def test_explicit_operator_code_prefix(self):
+        """``0 32 11 1234-5678`` — explicit carrier code (32 = Embratel)."""
+        text = "Discar 032 11 1234-5678 para atendimento interurbano."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+
 
 class TestPtEmails(TestCase):
     def test_extracts_simple_email(self):

--- a/lexnlp/extract/pt/tests/test_pii.py
+++ b/lexnlp/extract/pt/tests/test_pii.py
@@ -79,6 +79,10 @@ class TestPtPhones(TestCase):
         text = "Discar 032 11 1234-5678 para atendimento interurbano."
         ants = get_phone_annotation_list(text)
         self.assertEqual(1, len(ants))
+        # Surface must include the operator-code prefix and the body so
+        # the test fails if the regex starts matching only "11 1234-5678".
+        self.assertIn("032", ants[0].text)
+        self.assertIn("1234-5678", ants[0].text)
 
 
 class TestPtEmails(TestCase):

--- a/lexnlp/extract/pt/tests/test_pii.py
+++ b/lexnlp/extract/pt/tests/test_pii.py
@@ -1,0 +1,73 @@
+"""Tests for :mod:`lexnlp.extract.pt.pii`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.pt.pii import (
+    get_email_list,
+    get_phone_annotation_list,
+    get_phone_list,
+)
+
+
+class TestPtPhones(TestCase):
+    def test_extracts_mobile_with_parens(self):
+        text = "Contato: (11) 98765-4321 para mais informações."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("11987654321", ants[0].phone)
+        self.assertEqual("pt", ants[0].locale)
+
+    def test_extracts_landline_8_digits(self):
+        text = "Ligar para (21) 1234-5678."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("2112345678", ants[0].phone)
+
+    def test_extracts_with_country_code(self):
+        text = "Whatsapp +55 11 91234-5678 disponível."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("5511912345678", ants[0].phone)
+
+    def test_extracts_0800(self):
+        text = "Atendimento 0800 123 4567."
+        ants = get_phone_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("08001234567", ants[0].phone)
+
+    def test_does_not_match_short_number(self):
+        text = "Sala 123."
+        self.assertEqual([], get_phone_list(text))
+
+    def test_no_phone_in_plain_text(self):
+        self.assertEqual([], get_phone_list("Sem telefones aqui."))
+
+
+class TestPtEmails(TestCase):
+    def test_extracts_simple_email(self):
+        text = "Envie para contato@exemplo.com.br por favor."
+        emails = get_email_list(text)
+        self.assertEqual(1, len(emails))
+        self.assertEqual("contato@exemplo.com.br", emails[0])
+
+    def test_extracts_with_plus(self):
+        text = "Use info+legal@empresa.com para o setor jurídico."
+        emails = get_email_list(text)
+        self.assertEqual(1, len(emails))
+        self.assertEqual("info+legal@empresa.com", emails[0])
+
+    def test_extracts_multiple(self):
+        text = "Foo a@b.com bar c@d.org baz."
+        emails = get_email_list(text)
+        self.assertEqual(2, len(emails))
+
+    def test_no_email_in_plain_text(self):
+        self.assertEqual([], get_email_list("Sem endereços aqui."))

--- a/lexnlp/extract/pt/tests/test_ratios.py
+++ b/lexnlp/extract/pt/tests/test_ratios.py
@@ -1,0 +1,63 @@
+"""Tests for :mod:`lexnlp.extract.pt.ratios`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from decimal import Decimal
+from unittest import TestCase
+
+from lexnlp.extract.pt.ratios import (
+    get_ratio_annotation_list,
+    get_ratio_list,
+)
+
+
+class TestPtRatios(TestCase):
+    def test_extracts_colon_ratio(self):
+        text = "A proporção é 3:1 entre as partes."
+        ants = get_ratio_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        ant = ants[0]
+        self.assertEqual(Decimal("3"), ant.left)
+        self.assertEqual(Decimal("1"), ant.right)
+        self.assertEqual(Decimal("3"), ant.ratio)
+        self.assertEqual("pt", ant.locale)
+
+    def test_extracts_para_word(self):
+        text = "Razão de dois para um na composição."
+        # Word-form ("dois para um") not parsed by this module — only
+        # numeric operands. Numeric variant follows.
+        text2 = "Razão de 2 para 1 na composição."
+        ants = get_ratio_annotation_list(text2)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("2"), ants[0].left)
+        self.assertEqual(Decimal("1"), ants[0].right)
+
+    def test_extracts_slash(self):
+        text = "Margem de 5/4 no contrato."
+        ants = get_ratio_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual(Decimal("1.25"), ants[0].ratio)
+
+    def test_skips_clock_time(self):
+        # "10:30 a.m." should not match (clock time, not ratio).
+        ants = get_ratio_annotation_list("Reunião às 10:30 a.m.")
+        self.assertEqual(0, len(ants))
+
+    def test_zero_denominator_skipped(self):
+        ants = get_ratio_annotation_list("Razão 5:0 (impossível).")
+        self.assertEqual(0, len(ants))
+
+    def test_get_ratio_list_dicts(self):
+        results = get_ratio_list("3:1", return_sources=True)
+        self.assertEqual(1, len(results))
+        self.assertEqual(Decimal("3"), results[0][0])
+        self.assertIn("3:1", results[0][3])
+
+    def test_no_match_in_unrelated(self):
+        self.assertEqual([], get_ratio_annotation_list("Sem proporções aqui."))

--- a/lexnlp/extract/pt/tests/test_ratios.py
+++ b/lexnlp/extract/pt/tests/test_ratios.py
@@ -28,15 +28,18 @@ class TestPtRatios(TestCase):
         self.assertEqual(Decimal("3"), ant.ratio)
         self.assertEqual("pt", ant.locale)
 
-    def test_extracts_para_word(self):
-        text = "Razão de dois para um na composição."
-        # Word-form ("dois para um") not parsed by this module — only
-        # numeric operands. Numeric variant follows.
-        text2 = "Razão de 2 para 1 na composição."
-        ants = get_ratio_annotation_list(text2)
+    def test_extracts_para_word_with_numeric_operands(self):
+        """``para`` connector requires numeric operands (word-form not supported)."""
+        text = "Razão de 2 para 1 na composição."
+        ants = get_ratio_annotation_list(text)
         self.assertEqual(1, len(ants))
         self.assertEqual(Decimal("2"), ants[0].left)
         self.assertEqual(Decimal("1"), ants[0].right)
+
+    def test_word_form_ratios_not_supported(self):
+        """``dois para um`` is intentionally NOT parsed (numeric only)."""
+        text = "Razão de dois para um na composição."
+        self.assertEqual([], get_ratio_annotation_list(text))
 
     def test_extracts_slash(self):
         text = "Margem de 5/4 no contrato."

--- a/lexnlp/extract/pt/tests/test_real_corpus.py
+++ b/lexnlp/extract/pt/tests/test_real_corpus.py
@@ -73,9 +73,9 @@ class TestLeiAcessoInformacao(TestCase):
 
     def test_dates_extraction_is_sane(self):
         """
-        Verify date extraction yields a sufficient number of annotations and that every extracted year is between 1980 and 2025 inclusive.
+        Verify date extraction yields a sufficient number of annotations and that every extracted year falls in a realistic legislative range.
 
-        Materializes date annotations from the LAI corpus with `strict=False`, asserts more than 10 annotations are found, and asserts all annotation `date.year` values are within the inclusive range 1980–2025.
+        Materializes date annotations from the LAI corpus with `strict=False`, asserts more than 10 annotations are found, and asserts all annotation `date.year` values are within the inclusive range 1980 to ``datetime.date.today().year + 1`` (computed at runtime so the test does not bit-rot at year-end).
         """
         dates = list(get_date_annotations(self.text, strict=False))
         self.assertGreater(len(dates), 10)

--- a/lexnlp/extract/pt/tests/test_regulations.py
+++ b/lexnlp/extract/pt/tests/test_regulations.py
@@ -11,7 +11,12 @@ from unittest import TestCase
 import pandas as pd
 
 from lexnlp.extract.common.annotations.regulation_annotation import RegulationAnnotation
-from lexnlp.extract.pt.regulations import RegulationsParser, get_regulation_annotations, parser
+from lexnlp.extract.pt.regulations import (
+    PARAGRAPH_LEADING_REFERENCE_RE,
+    RegulationsParser,
+    get_regulation_annotations,
+    parser,
+)
 from lexnlp.tests.typed_annotations_tests import TypedAnnotationsTester
 
 
@@ -71,6 +76,39 @@ class TestRegulationsParserDataFrameInjection(TestCase):
         p = RegulationsParser(regulations_dataframe=custom_df)
         self.assertIn("lei", p.start_triggers)
         self.assertIn("decreto", p.start_triggers)
+
+    def test_paragraph_leading_paragrafo(self):
+        """``§ 2º do art. 14`` is captured by PARAGRAPH_LEADING_REFERENCE_RE."""
+        text = "Conforme § 2º do art. 14, deve-se proceder."
+        matches = list(PARAGRAPH_LEADING_REFERENCE_RE.finditer(text))
+        self.assertEqual(1, len(matches))
+        self.assertEqual("§ 2º do art. 14", matches[0].group("full"))
+
+    def test_paragraph_leading_inciso(self):
+        """``inciso II do art. 5º`` is captured."""
+        text = "Vide inciso II do art. 5º da norma."
+        matches = list(PARAGRAPH_LEADING_REFERENCE_RE.finditer(text))
+        self.assertEqual(1, len(matches))
+        self.assertEqual("inciso II do art. 5º", matches[0].group("full"))
+
+    def test_paragraph_leading_alinea(self):
+        """``alínea a do art. 12`` is captured."""
+        text = "Vide alínea a do art. 12 do regulamento."
+        matches = list(PARAGRAPH_LEADING_REFERENCE_RE.finditer(text))
+        self.assertEqual(1, len(matches))
+        self.assertEqual("alínea a do art. 12", matches[0].group("full"))
+
+    def test_paragraph_leading_via_parser(self):
+        """The parser surfaces paragraph-leading citations as RegulationAnnotations."""
+        text = (
+            "Aplica-se o § 2º do art. 14 da norma. "
+            "Bem como inciso II do art. 5º e alínea a do art. 12."
+        )
+        regs = list(parser.parse(text))
+        names = [r.name for r in regs]
+        self.assertIn("§ 2º do art. 14", names)
+        self.assertIn("inciso II do art. 5º", names)
+        self.assertIn("alínea a do art. 12", names)
 
     def test_custom_dataframe_non_start_rows_are_excluded(self):
         """

--- a/lexnlp/extract/pt/tests/test_trademarks.py
+++ b/lexnlp/extract/pt/tests/test_trademarks.py
@@ -30,6 +30,7 @@ class TestPtTrademarks(TestCase):
 
     def test_locale_is_pt(self):
         ants = get_trademark_annotation_list("Foo® bar")
+        self.assertGreaterEqual(len(ants), 1)  # avoid vacuous all() pass on empty list
         self.assertTrue(all(a.locale == "pt" for a in ants))
 
     def test_no_match_in_plain_text(self):

--- a/lexnlp/extract/pt/tests/test_trademarks.py
+++ b/lexnlp/extract/pt/tests/test_trademarks.py
@@ -1,0 +1,65 @@
+"""Tests for :mod:`lexnlp.extract.pt.trademarks`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.pt.trademarks import (
+    get_entity_suffix_list,
+    get_trademark_annotation_list,
+    get_trademark_list,
+)
+
+
+class TestPtTrademarks(TestCase):
+    def test_detects_registered_symbol(self):
+        text = "A Empresa® está registrada."
+        results = get_trademark_list(text)
+        self.assertTrue(any("®" in r for r in results))
+
+    def test_detects_tm_symbol(self):
+        text = "Marca™ pertence à empresa."
+        results = get_trademark_list(text)
+        self.assertTrue(any("™" in r for r in results))
+
+    def test_locale_is_pt(self):
+        ants = get_trademark_annotation_list("Foo® bar")
+        self.assertTrue(all(a.locale == "pt" for a in ants))
+
+    def test_no_match_in_plain_text(self):
+        self.assertEqual([], get_trademark_list("Sem marca registrada aqui."))
+
+
+class TestPtEntitySuffixes(TestCase):
+    def test_detects_ltda(self):
+        text = "A Construtora ABC Ltda. assinou o contrato."
+        ants = get_entity_suffix_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertIn("Ltda", ants[0].trademark)
+        self.assertIn("ABC", ants[0].trademark)
+
+    def test_detects_sa(self):
+        text = "Empresa XYZ S.A. é a contratante."
+        ants = get_entity_suffix_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertIn("S.A.", ants[0].trademark)
+
+    def test_detects_eireli(self):
+        text = "A Foo Bar EIRELI emitiu a nota."
+        ants = get_entity_suffix_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertIn("EIRELI", ants[0].trademark)
+
+    def test_detects_s_slash_a(self):
+        text = "A Empresa Z S/A pagou o débito."
+        ants = get_entity_suffix_list(text)
+        self.assertEqual(1, len(ants))
+
+    def test_no_suffix_match(self):
+        self.assertEqual([], get_entity_suffix_list("Texto sem empresa."))

--- a/lexnlp/extract/pt/tests/test_urls.py
+++ b/lexnlp/extract/pt/tests/test_urls.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`lexnlp.extract.pt.urls`."""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from unittest import TestCase
+
+from lexnlp.extract.pt.urls import (
+    URL_PTN_RE,
+    get_url_annotation_list,
+    get_urls,
+)
+
+
+class TestPtUrls(TestCase):
+    def test_extracts_https(self):
+        text = "Disponível em https://www.planalto.gov.br/ccivil_03/leis/L12527.htm"
+        urls = list(get_urls(text))
+        self.assertEqual(1, len(urls))
+        self.assertIn("planalto.gov.br", urls[0])
+
+    def test_locale_is_pt(self):
+        text = "Vide https://example.com.br para detalhes."
+        ants = get_url_annotation_list(text)
+        self.assertEqual(1, len(ants))
+        self.assertEqual("pt", ants[0].locale)
+
+    def test_reuses_en_pattern_object(self):
+        """The pt module exports the same regex object as EN to avoid drift."""
+        from lexnlp.extract.en.urls import URL_PTN_RE as EN_URL_PTN_RE
+
+        self.assertIs(URL_PTN_RE, EN_URL_PTN_RE)
+
+    def test_no_match_in_plain_text(self):
+        self.assertEqual([], list(get_urls("Sem links aqui.")))

--- a/lexnlp/extract/pt/trademarks.py
+++ b/lexnlp/extract/pt/trademarks.py
@@ -1,0 +1,113 @@
+"""Trademark and entity-suffix extraction for Portuguese (pt-BR).
+
+Mirrors :mod:`lexnlp.extract.en.trademarks` for the universal trademark
+markers (``™``, ``®``, ``(R)``, ``TM``) and additionally surfaces
+Brazilian commercial-entity suffixes that commonly mark a company name in
+contracts (``Ltda.``, ``S.A.``, ``S/A``, ``EIRELI``, ``MEI``, ``LTDA.``).
+
+The trademark regex is locale-agnostic, so we re-use the same shape as
+the English module. The named-phrase extraction (``NPExtractor``) used in
+:mod:`lexnlp.extract.en.trademarks` is English-only (NLTK pre-trained
+chunker), so we instead anchor the trademark regex to the surrounding
+context and emit one annotation per direct hit. Callers who need
+phrase-level grouping should fall back to :mod:`lexnlp.extract.ner`.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+
+import regex as re
+
+from lexnlp.extract.common.annotations.trademark_annotation import TrademarkAnnotation
+
+# Universal trademark markers — same shape as the EN regex but matched
+# against the full source text rather than NPExtractor phrases.
+TRADEMARK_PTN_RE = re.compile(
+    r"[\p{Lu}\p{N}][^\)]{0,80}?(?:[a-z]TM|[\s\(]TM(?:\W|$)|™|\s*\(R\)|Ⓡ|®)",
+    re.UNICODE,
+)
+
+# Brazilian commercial-entity suffixes. Captures the immediately preceding
+# capitalised token sequence as the company name. Matches ``XYZ Ltda.``,
+# ``Foo Bar S.A.``, ``Empresa S/A``, ``Foo EIRELI``.
+ENTITY_SUFFIX_RE = re.compile(
+    r"(?P<full>(?:[\p{Lu}][\p{L}\.&'-]*\s+){1,5}"
+    r"(?P<suffix>Ltda\.?|S\.?A\.?|S/A|EIRELI|ME|MEI|EPP|LTDA\.?))"
+    r"(?!\w)",
+    re.UNICODE,
+)
+
+
+def get_trademark_annotations(text: str) -> Iterator[TrademarkAnnotation]:
+    """Yield :class:`TrademarkAnnotation` for every ™/® mark in *text*.
+
+    The match is anchored on the trademark symbol itself and includes up
+    to 80 chars of preceding context (capped to keep matches local). Only
+    matches whose span lies fully within ``text`` are yielded.
+    """
+    if not TRADEMARK_PTN_RE.search(text):
+        return
+    for match in TRADEMARK_PTN_RE.finditer(text):
+        coords = match.span()
+        if coords[1] > len(text):
+            coords = (coords[0], len(text))
+        yield TrademarkAnnotation(
+            coords=coords, trademark=match.group(), text=match.group(), locale="pt"
+        )
+
+
+def get_trademarks(text: str) -> Iterator[str]:
+    """Yield the surface form of every trademark match in *text*."""
+    for ant in get_trademark_annotations(text):
+        yield ant.trademark
+
+
+def get_trademark_list(text: str) -> list[str]:
+    """Return all trademark strings in *text* as a list."""
+    return list(get_trademarks(text))
+
+
+def get_trademark_annotation_list(text: str) -> list[TrademarkAnnotation]:
+    """Return all trademark annotations in *text* as a list."""
+    return list(get_trademark_annotations(text))
+
+
+def get_entity_suffix_annotations(text: str) -> Iterator[TrademarkAnnotation]:
+    """Yield Brazilian commercial-entity suffixes (``Ltda.`` / ``S.A.`` …).
+
+    These are not technically trademarks but live in the same recognition
+    layer in legal contracts: they mark a company name and are commonly
+    extracted alongside ``®``/``™`` matches. The :class:`TrademarkAnnotation`
+    container is used so callers can iterate a single typed stream.
+    """
+    for match in ENTITY_SUFFIX_RE.finditer(text):
+        yield TrademarkAnnotation(
+            coords=match.span("full"),
+            trademark=match.group("full"),
+            text=match.group("full"),
+            locale="pt",
+        )
+
+
+def get_entity_suffix_list(text: str) -> list[TrademarkAnnotation]:
+    """Return all Brazilian commercial-entity suffix annotations as a list."""
+    return list(get_entity_suffix_annotations(text))
+
+
+__all__ = [
+    "ENTITY_SUFFIX_RE",
+    "TRADEMARK_PTN_RE",
+    "get_entity_suffix_annotations",
+    "get_entity_suffix_list",
+    "get_trademark_annotation_list",
+    "get_trademark_annotations",
+    "get_trademark_list",
+    "get_trademarks",
+]

--- a/lexnlp/extract/pt/urls.py
+++ b/lexnlp/extract/pt/urls.py
@@ -1,0 +1,47 @@
+"""URL extraction for Portuguese (pt-BR).
+
+URLs follow RFC 3986 / RFC 3987 regardless of surrounding natural
+language, so the pattern in :mod:`lexnlp.extract.en.urls` is fully reusable
+for pt-BR text. To avoid duplicating that regex (and the maintenance
+burden that would come with two copies drifting), this module re-exports
+the EN extractors and locale-tags any annotations it produces as ``"pt"``.
+"""
+
+__author__ = "ContraxSuite, LLC; LexPredict, LLC"
+__copyright__ = "Copyright 2015-2021, ContraxSuite, LLC"
+__license__ = "https://github.com/LexPredict/lexpredict-lexnlp/blob/2.3.0/LICENSE"
+__version__ = "2.3.0"
+__maintainer__ = "LexPredict, LLC"
+__email__ = "support@contraxsuite.com"
+
+
+from collections.abc import Iterator
+
+from lexnlp.extract.common.annotations.url_annotation import UrlAnnotation
+from lexnlp.extract.en.urls import URL_PTN_RE, get_url_list, get_urls
+
+
+def get_url_annotations(text: str) -> Iterator[UrlAnnotation]:
+    """Yield :class:`UrlAnnotation` (locale ``"pt"``) for every URL in *text*.
+
+    The underlying regex is locale-agnostic; this wrapper only swaps the
+    ``locale`` field so downstream code can route the annotation through
+    pt-BR pipelines.
+    """
+    for match in URL_PTN_RE.finditer(text):
+        coords = match.span()
+        yield UrlAnnotation(coords=coords, url=match.group(), text=match.group(), locale="pt")
+
+
+def get_url_annotation_list(text: str) -> list[UrlAnnotation]:
+    """Return all URL annotations in *text* as a list."""
+    return list(get_url_annotations(text))
+
+
+__all__ = [
+    "URL_PTN_RE",
+    "get_url_annotation_list",
+    "get_url_annotations",
+    "get_url_list",
+    "get_urls",
+]

--- a/lexnlp/ml/tests/test_model_card.py
+++ b/lexnlp/ml/tests/test_model_card.py
@@ -130,11 +130,14 @@ class TestModelCardMetadataValidation(TestCase):
             ModelCardMetadata()  # type: ignore[call-arg]
 
     def test_frozen(self) -> None:
+        import dataclasses
+
         md = ModelCardMetadata(description="x", license="", authors="")
-        with self.assertRaises((AttributeError, Exception)):
-            # type: ignore[misc] — intentionally mutating a frozen dataclass
-            # attribute to assert immutability is enforced at runtime.
-            md.description = "changed"  # type: ignore[misc]
+        # ``dataclasses.FrozenInstanceError`` is the precise exception raised
+        # when assigning to a frozen dataclass attribute. Use ``setattr`` to
+        # exercise the runtime path without needing a type-checker suppression.
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            setattr(md, "description", "changed")
 
     def test_tags_default_is_empty_tuple(self) -> None:
         md = ModelCardMetadata(description="x")

--- a/lexnlp/ml/tests/test_model_card.py
+++ b/lexnlp/ml/tests/test_model_card.py
@@ -125,9 +125,7 @@ class TestWriteModelCard(TestCase):
 class TestModelCardMetadataValidation(TestCase):
     def test_required_description(self) -> None:
         with self.assertRaises((TypeError, ValueError)):
-            # type: ignore[call-arg] — intentionally omitting the required
-            # ``description`` field to assert the runtime constructor fails.
-            ModelCardMetadata()  # type: ignore[call-arg]
+            ModelCardMetadata()  # type: ignore[call-arg] -- intentionally omitting required ``description`` to assert runtime constructor fails
 
     def test_frozen(self) -> None:
         import dataclasses

--- a/lexnlp/ml/tests/test_model_io.py
+++ b/lexnlp/ml/tests/test_model_io.py
@@ -422,7 +422,7 @@ class TestLoadLegacyAdditional:
         """
         path = tmp_path / "corrupt.pickle"
         path.write_bytes(b"not a pickle and not a joblib file")
-        with pytest.raises(Exception):
+        with pytest.raises(pickle.UnpicklingError):
             _load_legacy(path)
 
     def test_joblib_compress_0_round_trips_via_pickle_extension(

--- a/lexnlp/utils/tests/test_text_vectors.py
+++ b/lexnlp/utils/tests/test_text_vectors.py
@@ -183,7 +183,15 @@ class TestVectorizedLowerStringDType(TestCase):
 
 
 class TestVectorizedStripStringDType(TestCase):
-    def test_strips_unicode_whitespace(self):
+    def test_preserves_length_no_crash_on_unicode_whitespace(self):
+        """Vectorized strip must accept Unicode whitespace without crashing.
+
+        Whether ``\\u3000`` (ideographic space) is stripped depends on the
+        underlying NumPy ``vectorize_strip`` implementation, which has changed
+        between releases. We therefore only assert shape preservation here;
+        ASCII whitespace stripping is exercised by ``test_mixed_length_strings``
+        below.
+        """
         result = vectorized_strip(["\u3000foo\u3000", "bar"])
         # \u3000 is an ideographic space — strip should handle it
         # Result may or may not strip non-ASCII whitespace depending on

--- a/lexnlp/utils/tests/test_text_vectors.py
+++ b/lexnlp/utils/tests/test_text_vectors.py
@@ -193,10 +193,10 @@ class TestVectorizedStripStringDType(TestCase):
         below.
         """
         result = vectorized_strip(["\u3000foo\u3000", "bar"])
-        # \u3000 is an ideographic space — strip should handle it
-        # Result may or may not strip non-ASCII whitespace depending on
-        # the NumPy version; just verify no crash and correct length.
+        self.assertIsInstance(result, np.ndarray)
         self.assertEqual(len(result), 2)
+        # Element type stays string-like across NumPy versions.
+        self.assertTrue(all(isinstance(item, (str, np.str_)) for item in result))
 
     def test_mixed_length_strings(self):
         """Strings with very different lengths must all be stripped correctly."""

--- a/scripts/reexport_bundled_sklearn_models.py
+++ b/scripts/reexport_bundled_sklearn_models.py
@@ -237,8 +237,18 @@ def _sanitize_pandas_indices(obj, _seen: set[int] | None = None):
             else:
                 _sanitize_pandas_indices(value, _seen)
         return obj
-    if isinstance(obj, (list, set)):
-        for item in list(obj):
+    if isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, _pd.Index):
+                obj[i] = list(item)
+            else:
+                _sanitize_pandas_indices(item, _seen)
+        return obj
+    if isinstance(obj, (set, tuple)):
+        # Tuples and sets are immutable / unordered respectively, so we can't
+        # rewrite a contained ``pd.Index`` in place. Recurse into each item
+        # so any mutable sub-objects are still sanitized.
+        for item in obj:
             _sanitize_pandas_indices(item, _seen)
         return obj
 
@@ -253,9 +263,6 @@ def _sanitize_pandas_indices(obj, _seen: set[int] | None = None):
                     setattr(obj, key, list(value))
                 else:
                     _sanitize_pandas_indices(value, _seen)
-    if hasattr(obj, "steps"):
-        for _, step in obj.steps:
-            _sanitize_pandas_indices(step, _seen)
     return obj
 
 
@@ -290,8 +297,11 @@ def main(argv: Sequence[str]) -> int:
             )
             extra = ""
             if args.remove_legacy:
-                path.unlink()
-                extra = " removed-legacy=yes"
+                if target.exists():
+                    path.unlink()
+                    extra = " removed-legacy=yes"
+                else:
+                    extra = " removed-legacy=SKIPPED (target missing)"
             print(
                 f"reexport: {path} -> {target} legacy_warnings before={before} "
                 f"after={after}{extra}"


### PR DESCRIPTION
## Summary

Addresses outstanding review comments from PRs #21, #22, and #23, then adds Spanish and German identifier-extraction modules so the DE/ES locales gain feature parity with the existing pt-BR `identifiers.py`.

### PR23 follow-ups
- `lexnlp/extract/ner/__init__.py`: rewrite `_nltk_extract` on top of `TreebankWordTokenizer.span_tokenize` so character offsets stay correct when NLTK normalises tokens (`"`/`''`/contractions). Avoids the silent span drift in the original `text.find` loop.
- `lexnlp/extract/pt/definitions.py`: `match_pt_def_by_parenthesised_label` now emits one `PatternFound` per quoted label (label text becomes `entry.name`) and handles `ou`-joined alternatives that share coordinates.
- `lexnlp/extract/ml/classifier/spacy_token_sequence_model.py`: justify the `# noqa: E731` and add a `TYPE_CHECKING`-guarded `Language` return annotation on `_load_spacy_pipeline`.
- `scripts/reexport_bundled_sklearn_models.py`: `_sanitize_pandas_indices` now replaces `pd.Index` items inside lists, recurses through tuples/sets without trying to mutate them, and `--remove-legacy` skips deletion when the export target is missing.
- `lexnlp/extract/pt/tests/test_definitions.py`: new tests for the parenthesised-label matcher (single label, `ou`-joined alternatives, multi-group, no-match).
- `lexnlp/extract/pt/tests/test_regulations.py`: new tests for `PARAGRAPH_LEADING_REFERENCE_RE` (`§`, `inciso`, `alínea` variants + parser integration).
- `lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py`: snapshot/restore both `runtime_model.CATALOG` and `catalog_mod.CATALOG` in the `finally` block.
- `lexnlp/extract/pt/tests/test_real_corpus.py`: docstring no longer hard-codes 2025; describes the dynamic `today().year + 1` upper bound.

### PR22 follow-ups
- `lexnlp/extract/common/tests/test_countries.py`: drop unjustified `# type: ignore[arg-type]` and use `cast(Any, …)` to keep runtime intent.
- `lexnlp/ml/tests/test_model_card.py`: assert `dataclasses.FrozenInstanceError` via `setattr` instead of broad `Exception`.
- `lexnlp/ml/tests/test_model_io.py`: assert `pickle.UnpicklingError` precisely on double-failure.
- `lexnlp/utils/tests/test_text_vectors.py`: rename to `test_preserves_length_no_crash_on_unicode_whitespace` so the assertion strength matches the test name.

### PR21 follow-ups
Verified that the previously-flagged items are already in tree on this branch (`uvx pre-commit install`, `--frozen` on `uv sync`, `cosine_similarity` ndim check, `enable_metadata_routing` snapshot/restore, `_load_skops` ValueError, `read_csv_arrow` pyarrow-missing path, hub test double via `setattr`).

### DE/ES feature parity with pt-BR identifiers
Ports the design of `lexnlp/extract/pt/identifiers.py` into `lexnlp/extract/{de,es}/identifiers.py`:

- `lexnlp.extract.es.identifiers`: DNI / NIE / NIF / CIF extractors with check-letter validation (`TRWAGMYFPDXBNJZSQVHLCKE` for DNI/NIE, official mod-10 algorithm with `JABCDEFGHI` control letters for CIF). Frozen `EsIdentifierMatch` dataclass with `to_dictionary`.
- `lexnlp.extract.de.identifiers`: Steuer-IdNr (ISO 7064 MOD 11,10 + BZSt repeat-digit invariant), USt-IdNr (`DE` + 9 digits with MOD 11 check) and HRB/HRA candidates (regex-only, since the Handelsregister has no checksum). Frozen `DeIdentifierMatch` dataclass.
- Both `__init__.py` files export the new public surface.
- New unit tests cover validators (positive + negative), surface extraction, dict serialisation, and frozen-dataclass immutability.

## Test plan

- [ ] `uv run pytest lexnlp/extract/pt/tests/test_definitions.py lexnlp/extract/pt/tests/test_regulations.py`
- [ ] `uv run pytest lexnlp/extract/de/tests/test_identifiers.py lexnlp/extract/es/tests/test_identifiers.py`
- [ ] `uv run pytest lexnlp/ml/tests/test_model_card.py lexnlp/ml/tests/test_model_io.py lexnlp/utils/tests/test_text_vectors.py lexnlp/extract/common/tests/test_countries.py`
- [ ] `uv run pytest lexnlp/extract/ner/tests/test_hybrid_ner.py lexnlp/extract/en/contracts/tests/test_runtime_model_sklearn18.py`
- [ ] `uv run ruff check . && uv run ruff format --check .`

https://claude.ai/code/session_01K3DzqSzqpmSH5xTZ9EMpe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3DzqSzqpmSH5xTZ9EMpe2)_